### PR TITLE
Disable sshd by default after playbook run

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,5 +12,8 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "ansible/site.yml"
+    ansible.extra_vars = {
+      disable_sshd_after_run: false
+    }
   end
 end

--- a/ansible/roles/connectbox-pi/defaults/main.yml
+++ b/ansible/roles/connectbox-pi/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+disable_sshd_after_run: True

--- a/ansible/roles/connectbox-pi/handlers/main.yaml
+++ b/ansible/roles/connectbox-pi/handlers/main.yaml
@@ -2,7 +2,7 @@
 - name: reload php5-fpm
   service: name=php5-fpm state=restarted
 
-- name: Disable sshd
+- name: Stop and Disable sshd
   service:
     name: sshd
     state: stopped

--- a/ansible/roles/connectbox-pi/handlers/main.yaml
+++ b/ansible/roles/connectbox-pi/handlers/main.yaml
@@ -1,3 +1,9 @@
 ---
 - name: reload php5-fpm
   service: name=php5-fpm state=restarted
+
+- name: Disable sshd
+  service:
+    name: sshd
+    state: stopped
+    enabled: no

--- a/ansible/roles/connectbox-pi/tasks/main.yml
+++ b/ansible/roles/connectbox-pi/tasks/main.yml
@@ -93,6 +93,12 @@
   tags:
   - full-build-only
 
+- name: Make sure /boot/ssh does not exist on Raspbian so sshd isn't re-enabled on boot
+  file:
+    path: /boot/ssh
+    state: absent
+  when: disable_sshd_after_run==True and ansible_lsb["id"] == "Raspbian"
+
 # Run in a handler so sshd is disabled right at the end, at least to the
 #  extent that we can influence it. While handlers are run in the order that
 #  they are defined within a role, it's unclear how handlers are ordered
@@ -110,4 +116,4 @@
       - True
   changed_when: True
   when: disable_sshd_after_run==True
-  notify: Disable sshd
+  notify: Stop and Disable sshd

--- a/ansible/roles/connectbox-pi/tasks/main.yml
+++ b/ansible/roles/connectbox-pi/tasks/main.yml
@@ -92,3 +92,20 @@
     upgrade: safe
   tags:
   - full-build-only
+
+# Run in a handler so sshd is disabled right at the end, at least to the
+#  extent that we can influence it. While handlers are run in the order that
+#  they are defined within a role, it's unclear how handlers are ordered
+#  when multiple roles fire handlers.
+# sshd forks child processes to handle connections, so stopping sshd doesn't
+#  disconnect the session that's stopping sshd (or the control session if
+#  pipelining is in use), so we can just use a regular service task.
+#
+# This is a no-op force the handler to run (assuming the conditional passes)
+- name: Schedule disabling of sshd
+  assert:
+    that:
+      - True
+  changed_when: True
+  when: disable_sshd_after_run==True
+  notify: Disable sshd

--- a/ansible/roles/connectbox-pi/tasks/main.yml
+++ b/ansible/roles/connectbox-pi/tasks/main.yml
@@ -97,12 +97,14 @@
 #  extent that we can influence it. While handlers are run in the order that
 #  they are defined within a role, it's unclear how handlers are ordered
 #  when multiple roles fire handlers.
-# sshd forks child processes to handle connections, so stopping sshd doesn't
-#  disconnect the session that's stopping sshd (or the control session if
-#  pipelining is in use), so we can just use a regular service task.
+# sshd forks child processes to handle connections, so stopping and disabling
+#  sshd doesn't disconnect the session that's actually doing the stopping and
+#  disabling (or the control session if pipelining is in use). This means we
+#  we can use a regular ansible service task rather than needing to background
+#  the command that does the work.
 #
 # This is a no-op force the handler to run (assuming the conditional passes)
-- name: Schedule disabling of sshd
+- name: Schedule task to stop and disable sshd
   assert:
     that:
       - True

--- a/ci/script_run_on_non_pull_requests.sh
+++ b/ci/script_run_on_non_pull_requests.sh
@@ -39,7 +39,7 @@ setup_and_verify_infra( ) {
     done
     echo "OK";
     echo "Adding $target_host to inventory";
-    echo "$target_host ansible_ssh_user=admin ansible_ssh_private_key_file=$PEM_OUT" > inventory;
+    echo "$target_host disable_sshd_after_run=False ansible_ssh_user=admin ansible_ssh_private_key_file=$PEM_OUT" > inventory;
   done
 
   echo "Inventory follows:";

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,7 +34,7 @@ Note that this should be run on the same machine where you setup your virtualenv
 
 - Sample content is deployed by default. To prevent sample content being deployed, add `-e deploy_sample_content=False` to the `ansible-playbook` commandline.
 - The Wireless SSID can be changed from the admin interface but it can also be changed at deployment time. To specify a different ssid, add `-e ssid="<new ssid>"` to the `ansible-playbook` commandline e.g. `-e ssid="My Connectbox"`.
-- sshd is disabled by default at the end of the ansible playbook run. This is done because it addresses the problem of unauthorised remote access when default passwords are not changed, but does so in a way that it's easy to restore access if it was done by mistake. To leave sshd running at the end of the playbook run add `-e disable_sshd_after_run=False` to the `ansible-playbook` commandline.
+- sshd is stopped and disabled by default at the end of the ansible playbook run. This is done to addresses the problem of unauthorised remote access when default passwords are not changed, but does so in a way that it's easy to restore access if it was done by mistake. To leave sshd running at the end of the playbook run add `-e disable_sshd_after_run=False` to the `ansible-playbook` commandline. The [Raspbian security update](https://www.raspberrypi.org/blog/a-security-update-for-raspbian-pixel/) describes how to re-enable sshd if it was disabled by mistake.
 
 ## Use the ConnectBox
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,6 +34,7 @@ Note that this should be run on the same machine where you setup your virtualenv
 
 - Sample content is deployed by default. To prevent sample content being deployed, add `-e deploy_sample_content=False` to the `ansible-playbook` commandline.
 - The Wireless SSID can be changed from the admin interface but it can also be changed at deployment time. To specify a different ssid, add `-e ssid="<new ssid>"` to the `ansible-playbook` commandline e.g. `-e ssid="My Connectbox"`.
+- sshd is disabled by default at the end of the ansible playbook run. This is done because it addresses the problem of unauthorised remote access when default passwords are not changed, but does so in a way that it's easy to restore access if it was done by mistake. To leave sshd running at the end of the playbook run add `-e disable_sshd_after_run=False` to the `ansible-playbook` commandline.
 
 ## Use the ConnectBox
 


### PR DESCRIPTION
Overrideable by ansible variables (commandline, inventory or otherwise) to prevent disabling. sshd is not disabled in Vagrantfile or in CI runs. Documentation added.

Given this is a disruptive workflow change (albeit a documented one), I wanted to get input before merging. @kldavis4 @matheweis , any comments?