### PR TITLE
Changes needed for OrangePi Zero

### DIFF
--- a/ansible/group_vars/orange_pi_zero
+++ b/ansible/group_vars/orange_pi_zero
@@ -4,6 +4,5 @@
 wireless_channel: 3
 
 # Ansible doesn't detect CPU core count correctly, so override it here
-# (Also 1 worker process might perform better given the resource limitations)
-nginx_worker_processes: 1
+nginx_worker_processes: 4
 

--- a/ansible/group_vars/orange_pi_zero
+++ b/ansible/group_vars/orange_pi_zero
@@ -1,0 +1,3 @@
+---
+nginx_worker_processes: 1
+

--- a/ansible/group_vars/orange_pi_zero
+++ b/ansible/group_vars/orange_pi_zero
@@ -3,5 +3,7 @@
 # Channel 1 appears to be problematic on the OPi Zero; use anything else
 wireless_channel: 3
 
+# Ansible doesn't detect CPU core count correctly, so override it here
+# (Also 1 worker process might perform better given the resource limitations)
 nginx_worker_processes: 1
 

--- a/ansible/group_vars/orange_pi_zero
+++ b/ansible/group_vars/orange_pi_zero
@@ -1,3 +1,7 @@
 ---
+
+# Channel 1 appears to be problematic on the OPi Zero; use anything else
+wireless_channel: 3
+
 nginx_worker_processes: 1
 

--- a/ansible/roles/network-interfaces/tasks/main.yml
+++ b/ansible/roles/network-interfaces/tasks/main.yml
@@ -1,4 +1,11 @@
 ---
+- name: Stop NetworkManager
+  service: name=network-manager state=stopped enabled=no
+
+- name: Remove NetworkManager
+  apt: pkg=network-manager
+       state=absent
+
 - name: Configure network interfaces
   template:
     src: etc_network_interfaces.j2

--- a/ansible/roles/network-interfaces/tasks/main.yml
+++ b/ansible/roles/network-interfaces/tasks/main.yml
@@ -1,6 +1,13 @@
 ---
+
+- name: Check if NetworkManager package is installed
+  shell: dpkg -l network-manager
+  register: nm_installed_check
+  failed_when: nm_installed_check.rc > 1
+
 - name: Stop NetworkManager
   service: name=network-manager state=stopped enabled=no
+  when: nm_installed_check == 0
 
 - name: Remove NetworkManager
   apt: pkg=network-manager

--- a/ansible/roles/network-interfaces/tasks/main.yml
+++ b/ansible/roles/network-interfaces/tasks/main.yml
@@ -6,12 +6,16 @@
   failed_when: nm_installed_check.rc > 1
 
 - name: Stop NetworkManager
-  service: name=network-manager state=stopped enabled=no
+  service:
+    name: network-manager
+    state: stopped
+    enabled: no
   when: nm_installed_check == 0
 
 - name: Remove NetworkManager
-  apt: pkg=network-manager
-       state=absent
+  apt:
+    pkg: network-manager
+    state: absent
 
 - name: Configure network interfaces
   template:

--- a/ansible/roles/network-interfaces/tasks/main.yml
+++ b/ansible/roles/network-interfaces/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Check if NetworkManager package is installed
-  shell: dpkg -l network-manager
+  command: dpkg -l network-manager
   register: nm_installed_check
   failed_when: nm_installed_check.rc > 1
 

--- a/ansible/roles/network-interfaces/tasks/main.yml
+++ b/ansible/roles/network-interfaces/tasks/main.yml
@@ -10,7 +10,7 @@
     name: network-manager
     state: stopped
     enabled: no
-  when: nm_installed_check == 0
+  when: nm_installed_check.rc == 0
 
 - name: Remove NetworkManager
   apt:

--- a/ansible/roles/network-interfaces/templates/etc_network_interfaces.j2
+++ b/ansible/roles/network-interfaces/templates/etc_network_interfaces.j2
@@ -7,7 +7,8 @@ source-directory /etc/network/interfaces.d
 auto lo
 iface lo inet loopback
 
-iface eth0 inet manual
+allow-hotplug eth0
+iface eth0 inet dhcp
 
 allow-hotplug {{ client_facing_if }}
 iface {{ client_facing_if }} inet static

--- a/ansible/roles/wifi-ap/defaults/main.yml
+++ b/ansible/roles/wifi-ap/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 ssid: "ConnectBox - Free Media"
+wireless_channel: 3
 ieee80211n_enabled: 0

--- a/ansible/roles/wifi-ap/defaults/main.yml
+++ b/ansible/roles/wifi-ap/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 ssid: "ConnectBox - Free Media"
-wireless_channel: 3
+wireless_channel: 1
 ieee80211n_enabled: 0

--- a/ansible/roles/wifi-ap/templates/hostapd.conf.j2
+++ b/ansible/roles/wifi-ap/templates/hostapd.conf.j2
@@ -18,7 +18,7 @@ hw_mode=g
 ieee80211n={{ ieee80211n_enabled }}
 
 # ACS is not supported on the brcmfmac driver (onboard wifi in rpi3)
-channel=1
+channel={{ wireless_channel }}
 macaddr_acl=0 # accept unless in deny list
 
 # IEEE 802.11 specifies two authentication algorithms. hostapd can be


### PR DESCRIPTION
This PR is for the changes needed to get ConnectBox up and running on the OrangePi Zero (and probably most other Armbian based devices as well...)

The changes include:

1f118c5 - Using dhcp to configure eth0. Not sure how dhcp was working on RPi before, but Armbian was not having the "inet manual" approach. Changing this to the usual dhcp configured method seems to work fine on both Armbian and Debain/RPi

867baca, 4cd62fe, da78487 - NetworkManager does not play nice with hostapd. At best the wlan0 device could be excluded manually via a [keyfile] unmanaged-devices=... config, but since NM wasn't buying us anything we decided to remove it entirely. Since RPi didn't have it to begin with, it made sense to remove NM entirely any time it was found to be installed.

bd4f0c9 - OrangePi Zero appears to have a bug with wifi channel 1, so the channel was moved off to a separate variable to allow for overrides / different defaults as needed.

f78cd28 - A bug in Ansible prevents the number of CPUs from being detected properly on Armbian, in turn causing nginx to fail miserably. Manually override this for the orange_pi_zero devices fixes the issue.
