### PR TITLE
Disable user accounts with insecure default passwords

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,7 +13,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "ansible/site.yml"
     ansible.extra_vars = {
-      disable_sshd_after_run: false
+      developer_mode: false
     }
   end
 end

--- a/ansible/group_vars/armbian
+++ b/ansible/group_vars/armbian
@@ -1,0 +1,3 @@
+---
+ansible_user: root
+user_account_to_disable: root

--- a/ansible/group_vars/armbian
+++ b/ansible/group_vars/armbian
@@ -1,3 +1,2 @@
 ---
 ansible_user: root
-user_account_to_disable: root

--- a/ansible/group_vars/raspbian
+++ b/ansible/group_vars/raspbian
@@ -1,3 +1,2 @@
 ---
 ansible_user: pi
-user_account_to_disable: pi

--- a/ansible/group_vars/raspbian
+++ b/ansible/group_vars/raspbian
@@ -1,0 +1,3 @@
+---
+ansible_user: pi
+user_account_to_disable: pi

--- a/ansible/inventory.example
+++ b/ansible/inventory.example
@@ -14,12 +14,13 @@ raspberry_pi_3
 
 [armbian:children]
 orange_pi_zero
+pine64
 
 [raspberry_pi_3]
 #192.168.20.183 ansible_user=pi wireless_country_code=AU
 
 [orange_pi_zero]
-#192.168.20.184 ansible_user=pi wireless_country_code=AU
+#192.168.20.184 ansible_user=root wireless_country_code=AU
 
 [pine64]
 #192.168.20.185 ansible_user=root wireless_country_code=AU

--- a/ansible/inventory.example
+++ b/ansible/inventory.example
@@ -9,6 +9,12 @@
 # If your device has a WiFi access point, replace the wireless_country_code
 # with your two-letter country code (see https://git.kernel.org/cgit/linux/kernel/git/sforshee/wireless-regdb.git/tree/db.txt for a list of valid values)
 #
+[raspbian:children]
+raspberry_pi_3
+
+[armbian:children]
+orange_pi_zero
+
 [raspberry_pi_3]
 #192.168.20.183 ansible_user=pi wireless_country_code=AU
 

--- a/ansible/roles/bootstrap/tasks/main.yml
+++ b/ansible/roles/bootstrap/tasks/main.yml
@@ -55,4 +55,3 @@
     when: ip_show_wlan0.rc != 0
 
   when: ansible_lsb["id"] == "Debian"
-

--- a/ansible/roles/connectbox-pi/defaults/main.yml
+++ b/ansible/roles/connectbox-pi/defaults/main.yml
@@ -1,9 +1,5 @@
 ---
-disable_sshd_after_run: True
-# Overridden in group_vars.
-user_account_to_disable: ""
-# Disables account unless overridden
-user_account_pw_hash: ""
+developer_mode: False
 # Command to run at the end of the playbook run to potentially disable
 # accounts and sshd
 final_command: ""

--- a/ansible/roles/connectbox-pi/defaults/main.yml
+++ b/ansible/roles/connectbox-pi/defaults/main.yml
@@ -1,2 +1,9 @@
 ---
 disable_sshd_after_run: True
+# Overridden in group_vars.
+user_account_to_disable: ""
+# Disables account unless overridden
+user_account_pw_hash: ""
+# Command to run at the end of the playbook run to potentially disable
+# accounts and sshd
+final_command: ""

--- a/ansible/roles/connectbox-pi/handlers/main.yaml
+++ b/ansible/roles/connectbox-pi/handlers/main.yaml
@@ -2,8 +2,13 @@
 - name: reload php5-fpm
   service: name=php5-fpm state=restarted
 
+# Skip lint because there's no way that ansible-lint can know at build time
+#  that we're legitimately use shell because of the && that is always
+#  present when this is run.
 - name: Run final disabling commands
   shell: "'{{ final_command | quote }}'"
   args:
     warn: no
   when: final_command != ""
+  tags:
+  - skip_ansible_lint

--- a/ansible/roles/connectbox-pi/handlers/main.yaml
+++ b/ansible/roles/connectbox-pi/handlers/main.yaml
@@ -2,8 +2,8 @@
 - name: reload php5-fpm
   service: name=php5-fpm state=restarted
 
-- name: Stop and Disable sshd
-  service:
-    name: ssh
-    state: stopped
-    enabled: no
+- name: Run final disabling commands
+  shell: "'{{ final_command | quote }}'"
+  args:
+    warn: no
+  when: final_command != ""

--- a/ansible/roles/connectbox-pi/tasks/main.yml
+++ b/ansible/roles/connectbox-pi/tasks/main.yml
@@ -97,20 +97,13 @@
   file:
     path: /boot/ssh
     state: absent
-  when: disable_sshd_after_run == True and ansible_lsb["id"] == "Raspbian"
+  when: not developer_mode and ansible_lsb["id"] == "Raspbian"
 
 # Disable the main user account unless as password hash is provided
 - name: Schedule disabling of user account
   set_fact:
-    final_command: "/usr/sbin/usermod --lock --shell /usr/sbin/nologin {{ user_account_to_disable }}"
-  when: user_account_to_disable != "" and user_account_pw_hash == ""
-
-# Set the password on the user account
-- name: Set user account password with supplied hash
-  user:
-    name: "{{ user_account_to_disable }}"
-    password: "{{ user_account_pw_hash }}"
-  when: user_account_to_disable != "" and user_account_pw_hash != ""
+    final_command: "/usr/sbin/usermod --lock --shell /usr/sbin/nologin {{ ansible_user }}"
+  when: not developer_mode
 
 # sshd forks child processes to handle connections, so stopping and disabling
 #  sshd doesn't disconnect the session that's actually doing the stopping and
@@ -119,7 +112,7 @@
 - name: Schedule disabling of sshd
   set_fact:
     final_command: "{{ (final_command == '') | ternary('systemctl disable ssh && systemctl stop ssh', ['systemctl disable ssh && systemctl stop ssh', final_command] | join(' && ')) }}"
-  when: disable_sshd_after_run == True
+  when: not developer_mode
 
 # Run the final commands in a handler so any disabling is performed right at
 #  the end of the playbook run, to extent that we can influence it. While

--- a/ansible/roles/connectbox-pi/tasks/main.yml
+++ b/ansible/roles/connectbox-pi/tasks/main.yml
@@ -97,23 +97,40 @@
   file:
     path: /boot/ssh
     state: absent
-  when: disable_sshd_after_run==True and ansible_lsb["id"] == "Raspbian"
+  when: disable_sshd_after_run == True and ansible_lsb["id"] == "Raspbian"
 
-# Run in a handler so sshd is disabled right at the end, at least to the
-#  extent that we can influence it. While handlers are run in the order that
-#  they are defined within a role, it's unclear how handlers are ordered
-#  when multiple roles fire handlers.
+# Disable the main user account unless as password hash is provided
+- name: Schedule disabling of user account
+  set_fact:
+    final_command: "/usr/sbin/usermod --lock --shell /usr/sbin/nologin {{ user_account_to_disable }}"
+  when: user_account_to_disable != "" and user_account_pw_hash == ""
+
+# Set the password on the user account
+- name: Set user account password with supplied hash
+  user:
+    name: "{{ user_account_to_disable }}"
+    password: "{{ user_account_pw_hash }}"
+  when: user_account_to_disable != "" and user_account_pw_hash != ""
+
 # sshd forks child processes to handle connections, so stopping and disabling
 #  sshd doesn't disconnect the session that's actually doing the stopping and
-#  disabling (or the control session if pipelining is in use). This means we
-#  we can use a regular ansible service task rather than needing to background
-#  the command that does the work.
+#  disabling (or the control session if pipelining is in use) so we stop sshd
+#  before any potential commands to disable user accounts
+- name: Schedule disabling of sshd
+  set_fact:
+    final_command: "{{ (final_command == '') | ternary('systemctl disable ssh && systemctl stop ssh', ['systemctl disable ssh && systemctl stop ssh', final_command] | join(' && ')) }}"
+  when: disable_sshd_after_run == True
+
+# Run the final commands in a handler so any disabling is performed right at
+#  the end of the playbook run, to extent that we can influence it. While
+#  handlers are run in the order that they are defined within a role, it's
+#  unclear how handlers are ordered when multiple roles fire handlers.
 #
 # This is a no-op force the handler to run (assuming the conditional passes)
-- name: Schedule task to stop and disable sshd
+- name: Schedule task to do final disabling
   assert:
     that:
       - True
+  when: final_command != ""
   changed_when: True
-  when: disable_sshd_after_run==True
-  notify: Stop and Disable sshd
+  notify: Run final disabling commands

--- a/ci/script_run_on_non_pull_requests.sh
+++ b/ci/script_run_on_non_pull_requests.sh
@@ -38,6 +38,9 @@ setup_and_verify_infra( ) {
       sleep 1;
     done
     echo "OK";
+    # We do not specify a user_account_pw_hash (to prevent account locking)
+    #  because debian group_vars do not specify a user_account to lock which
+    #  means the account won't be locked.
     echo "Adding $target_host to inventory";
     echo "$target_host disable_sshd_after_run=False ansible_ssh_user=admin ansible_ssh_private_key_file=$PEM_OUT" > inventory;
   done

--- a/ci/script_run_on_non_pull_requests.sh
+++ b/ci/script_run_on_non_pull_requests.sh
@@ -38,11 +38,10 @@ setup_and_verify_infra( ) {
       sleep 1;
     done
     echo "OK";
-    # We do not specify a user_account_pw_hash (to prevent account locking)
-    #  because debian group_vars do not specify a user_account to lock which
-    #  means the account won't be locked.
+    # Specify developer mode so the machine isn't locked down (we need access
+    #  (to run the tests)
     echo "Adding $target_host to inventory";
-    echo "$target_host disable_sshd_after_run=False ansible_ssh_user=admin ansible_ssh_private_key_file=$PEM_OUT" > inventory;
+    echo "$target_host developer_mode=True ansible_ssh_user=admin ansible_ssh_private_key_file=$PEM_OUT" > inventory;
   done
 
   echo "Inventory follows:";

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -12,7 +12,7 @@ Download the [Debian Jessie Pine64 Armbian Server Legacy Image](https://www.armb
 
 ## Get Ansible
 
-This project uses Ansible v2.1+ with some additional, optional tools. Ansible connects to the Raspberry Pi to perform setup activities but is actually run from a different machine, like a separate server or a workstation. There are many ways to install Ansible, but package managers normally have an outdated version that is not suitable. Steps for installing to a python virtualenv are included below, as one way to install a suitable version and some additional tools. From the directory containing this README, run:
+This project uses Ansible v2.1+ with some additional, optional tools. Ansible connects to the device to perform setup activities but is actually run from a different machine, like a separate server or a workstation. There are many ways to install Ansible, but package managers normally have an outdated version that is not suitable. Steps for installing to a python virtualenv are included below, as one way to install a suitable version and some additional tools. From the directory containing this README, run:
 
 ```
 $ mkdir ~/.virtualenvs
@@ -25,7 +25,7 @@ $ pip install -r requirements.txt
 
 Note that this should be run on the same machine where you setup your virtualenv - don't try to run it on the device itself.
 
-__A default ansible-playbook run will disable sshd and lock out the default user account on the Raspberry Pi. Read "Optional Ansible Arguments" if you don't want this__
+__A default ansible-playbook run will disable sshd and lock out the default user account. Read "Optional Ansible Arguments" if you don't want this__
 
 The rest of this guide assumes that your device is attached to the network via its ethernet port, so that the wifi interface can be configured as an AP. Make a note of the IP address associated with the ethernet interface when it boots.
 
@@ -40,8 +40,7 @@ The rest of this guide assumes that your device is attached to the network via i
 
 - Sample content is deployed by default. To prevent sample content being deployed, add `-e deploy_sample_content=False` to the `ansible-playbook` commandline.
 - The Wireless SSID can be changed from the admin interface but it can also be changed at deployment time. To specify a different ssid, add `-e ssid="<new ssid>"` to the `ansible-playbook` commandline e.g. `-e ssid="My Connectbox"`.
-- sshd is stopped and disabled by default at the end of the ansible playbook run. This is done to addresses the problem of unauthorised remote access when default passwords are not changed, but does so in a way that it's easy to restore access if it was done by mistake. To leave sshd running at the end of the playbook run add `-e disable_sshd_after_run=False` to the `ansible-playbook` commandline. The [Raspbian security update](https://www.raspberrypi.org/blog/a-security-update-for-raspbian-pixel/) describes how to re-enable sshd if it was disabled by mistake.
-- The default user account is locked at the end of the ansible playbook run. This is done to prevent unauthorised access to the console via ssh using the default Raspbian username and password. To prevent the account being locked, generate a crypt(3) password hash and add `-e 'user_account_pw_hash=your-hash-string'` to the `ansible-playbook` commandline. The [Ansible documentation](http://docs.ansible.com/ansible/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module) provides instructions on generating crypt(3) format hashes. Raspbian expects hashes in sha-512 format. If you mistakenly lock your account follow the instructions at [Reset a lost Raspberry Pi password)[http://www.raspberrypi-spy.co.uk/2014/08/how-to-reset-a-forgotten-raspberry-pi-password/)
+- sshd is stopped and disabled by default at the end of the ansible playbook run, and the user account is locked (with `usermod -L`). This is done to prevent unauthorised remote access and console access, particularly if operating system default passwords are not changed. If you do not want this to happen add `-e developer_mode=False` to the `ansible-playbook` commandline, but realise that this leaves the device in an insecure mode. If you have inadvertently locked yourself out, the [Raspbian security update](https://www.raspberrypi.org/blog/a-security-update-for-raspbian-pixel/) describes how to re-enable sshd and you can re-enable the account using information at RaspberryPi Spy - [Reset a lost Raspberry Pi password)[http://www.raspberrypi-spy.co.uk/2014/08/how-to-reset-a-forgotten-raspberry-pi-password/)
 
 ## Use the ConnectBox
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -25,6 +25,8 @@ $ pip install -r requirements.txt
 
 Note that this should be run on the same machine where you setup your virtualenv - don't try to run it on the device itself.
 
+__A default ansible-playbook run will disable sshd and lock out the default user account on the Raspberry Pi. Read "Optional Ansible Arguments" if you don't want this__
+
 The rest of this guide assumes that your device is attached to the network via its ethernet port, so that the wifi interface can be configured as an AP. Make a note of the IP address associated with the ethernet interface when it boots.
 
 1. cd into the `ansible` directory in this project.
@@ -39,6 +41,7 @@ The rest of this guide assumes that your device is attached to the network via i
 - Sample content is deployed by default. To prevent sample content being deployed, add `-e deploy_sample_content=False` to the `ansible-playbook` commandline.
 - The Wireless SSID can be changed from the admin interface but it can also be changed at deployment time. To specify a different ssid, add `-e ssid="<new ssid>"` to the `ansible-playbook` commandline e.g. `-e ssid="My Connectbox"`.
 - sshd is stopped and disabled by default at the end of the ansible playbook run. This is done to addresses the problem of unauthorised remote access when default passwords are not changed, but does so in a way that it's easy to restore access if it was done by mistake. To leave sshd running at the end of the playbook run add `-e disable_sshd_after_run=False` to the `ansible-playbook` commandline. The [Raspbian security update](https://www.raspberrypi.org/blog/a-security-update-for-raspbian-pixel/) describes how to re-enable sshd if it was disabled by mistake.
+- The default user account is locked at the end of the ansible playbook run. This is done to prevent unauthorised access to the console via ssh using the default Raspbian username and password. To prevent the account being locked, generate a crypt(3) password hash and add `-e 'user_account_pw_hash=your-hash-string'` to the `ansible-playbook` commandline. The [Ansible documentation](http://docs.ansible.com/ansible/faq.html#how-do-i-generate-crypted-passwords-for-the-user-module) provides instructions on generating crypt(3) format hashes. Raspbian expects hashes in sha-512 format. If you mistakenly lock your account follow the instructions at [Reset a lost Raspberry Pi password)[http://www.raspberrypi-spy.co.uk/2014/08/how-to-reset-a-forgotten-raspberry-pi-password/)
 
 ## Use the ConnectBox
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,7 +16,7 @@ Whether you're using Vagrant or developing directly against a device, you'll nee
 
 ## Developing against a Device
 
-1. This is identical to deploying a new device, so follow the instructions in the [deployment.md](deployment.md) documentation. You probably want to run the Ansible playbook many times as you do your development, so you will likely want to specify the `disable_sshd_after_run` variable.
+1. This is identical to deploying a new device, so follow the instructions in the [deployment.md](deployment.md) documentation. You probably want to run the Ansible playbook many times as you do your development, so you will likely want to specify the `developer_mode` variable on your commandline on in the Ansible inventory.
 
 1. You can access the ConnectBox site by connecting to a WiFi point named "ConnectBox - Free Media". Once connected to the WiFi point, go somewhere (anywhere) in your browser and you should be redirected to the ConnectBox site.
 1. You can also access the ConnectBox Site over ethernet. To do so add an entry in `/etc/hosts` on the machine where you ran Ansible, add the line `<ip-of-your-device> connectbox.local` . Then browse to http://connectbox.local


### PR DESCRIPTION
Fixes #74 

- Lock user account by default at the end of the playbook run
- Provide a mechanism that prevents account locking if a password hash is provided
- Introduce group_vars for armbian and raspbian and change example inventory to introduce required structure
- Change mechanism for disabling and stopping sshd at the end of the playbook run (no functional change, though)
- Add supporting doco

This is an invasive change, so I’d like input, please.

@kldavis4 @matheweis you’ll need to update your inventory files to contain the changes in the inventory.example if you’re going to run this branch of the playbook (indeed, you’ll need those changes once this merges anyway)

@matheweis , would you mind running this against your OPi to confirm that it disables the default account unless a password hash is provided, please? The armbian doco suggests it’s root, but I don’t have my armbian machine up yet.