### PR TITLE
Make openresolv and dnsmasq play nicely together

### DIFF
--- a/ansible/roles/dns-dhcp/files/etc_default_dnsmasq
+++ b/ansible/roles/dns-dhcp/files/etc_default_dnsmasq
@@ -1,0 +1,22 @@
+# This file has five functions:
+# 1) to completely disable starting dnsmasq,
+# 2) to set DOMAIN_SUFFIX by running `dnsdomainname`
+# 3) to select an alternative config file
+#    by setting DNSMASQ_OPTS to --conf-file=<file>
+# 4) to tell dnsmasq to read the files in /etc/dnsmasq.d for
+#    more configuration variables.
+# 5) to stop the resolvconf package from controlling dnsmasq's
+#    idea of which upstream nameservers to use.
+#
+# Whether or not to run the dnsmasq daemon; set to 0 to disable.
+ENABLED=1
+
+# By default search this drop directory for configuration options.
+# Libvirt leaves a file here to make the system dnsmasq play nice.
+# Comment out this line if you don't want this. The dpkg-* are file
+# endings which cause dnsmasq to skip that file. This avoids pulling
+# in backups made by dpkg.
+CONFIG_DIR=/etc/dnsmasq.d,.dpkg-dist,.dpkg-old,.dpkg-new
+
+# http://raspberrypi.stackexchange.com/questions/37439/proper-way-to-prevent-dnsmasq-from-overwriting-dns-server-list-supplied-by-dhcp
+DNSMASQ_EXCEPT=lo

--- a/ansible/roles/dns-dhcp/handlers/main.yml
+++ b/ansible/roles/dns-dhcp/handlers/main.yml
@@ -2,7 +2,7 @@
 # A reload with the current ordering, when installed on a vanilla system
 # results in a dnsmasq that doesn't offer DHCP addresses. A restart seems to
 # fix that but it would be nice to know why a reload was insufficient
-- name: Reload dnsmasq
+- name: Restart dnsmasq
   service:
     name: dnsmasq
     state: restarted

--- a/ansible/roles/dns-dhcp/tasks/main.yml
+++ b/ansible/roles/dns-dhcp/tasks/main.yml
@@ -1,41 +1,4 @@
 ---
-# Openresolv, by default, wants to update /etc/resolv.conf to use dnsmasq
-#  as a local resolver. We stop it from doing that with resolvconf=NO
-# If 127.0.0.1 is a system resolver when dnsmasq is running, all on-box
-#  queries are answered with the local client-facing ip address. This breaks
-#  apt updates and other stuff that needs a working resolver. This means that
-#  clients get different results to their DNS queries (which are served
-#  from dnsmasq) from queries run on-box i.e. using system resolver
-#
-#  This does not work with the openresolv that ships with raspbian-lite
-#   based on jessie, which is why we need to upgrade it below
-- name: Tell openresolv not to touch /etc/resolv.conf
-  lineinfile:
-    dest: /etc/resolvconf.conf
-    line: resolvconf=NO
-    state: present
-  register: resolvconf_conf_changed
-
-- name: Upgrade openresolv to a version that supports resolvconf=NO
-  apt:
-    name: openresolv
-    state: latest
-    default_release: jessie-backports
-
-# This can't be a handler, as we need this config to be in place when
-#  we install and start dnsmasq. If it is not, then openresolv removes
-#  the entries in /etc/resolv.conf and breaks DNS
-- name: Reload openresolv with config
-  command: /sbin/resolvconf -u
-  when: resolvconf_conf_changed.changed
-  tags:
-  - skip_ansible_lint
-
-- name: Install dnsmasq
-  apt:
-    name: dnsmasq
-    state: present
-
 - name: Copy dnsmasq configuration
   template:
     src: etc_dnsmasq.conf.j2
@@ -43,8 +6,15 @@
     owner: root
     group: root
     mode: 0644
-    validate: dnsmasq --test --conf-file=%s
-  notify: Reload dnsmasq
+  notify: Restart dnsmasq
+
+# Note that the handler must do a restart instead of a reload as some of
+#  these defaults are only read at startup
+- name: Create defaults for dnsmasq used when starting dnsmasq (including not adding the local machine as a resolver)
+  copy:
+    src: etc_default_dnsmasq
+    dest: /etc/default/dnsmasq
+  notify: Restart dnsmasq
 
 # This is necessary because nginx redirects to the hostname, but the hostname
 #  is listed in /etc/hosts and associated with 127.0.0.1 (so dnsmasq uses it
@@ -56,6 +26,18 @@
   lineinfile:
     dest: /etc/hosts
     line: "{{ client_facing_if_ip_address }} {{ connectbox_default_hostname }}"
+
+# Install dnsmasq after the config files are in place.
+# Installation of dnsmasq starts the service, and if the config files aren't
+#  correct when the service starts, it removes the upstream resolver from
+#  /etc/resolv.conf, and it's necessary to restart dhclient to repopulate
+#  /etc/resolv.conf with the upstream resolver.
+# Unfortunately this means we can't use the validate clause on the
+#  dnsmasq.conf template task
+- name: Install dnsmasq
+  apt:
+    name: dnsmasq
+    state: present
 
 - name: Start and enable dnsmasq
   service:


### PR DESCRIPTION
- specifying resolvconf=NO in /etc/resolvconf.conf meant that
  /etc/resolv.conf was unmanaged and not even updated by dhclient which
  meant that moving a device to a new network (or using an image
  generated on a different network) caused DNS to break. Now we don't
  need to bludgeon openresolv so that it doesn't touch /etc/resolv.conf
  and we have a setup that respects dhclient