### PR TITLE
Use connectbox jessie-backports repo for Raspbian

### DIFF
--- a/ansible/group_vars/raspbian
+++ b/ansible/group_vars/raspbian
@@ -1,2 +1,10 @@
 ---
 ansible_user: pi
+
+# No Debian armhf backports repo exists that runs on ARMv6 so we have our
+#  own for the packages that we require
+jessie_backports_repo: deb https://eisbox.net/downloads/connectbox/repo jessie-backports main
+
+# Matt's signing key, currently used to sign the repo
+jessie_backports_signing_keys:
+  - D8E4364592F3A749

--- a/ansible/roles/bootstrap/defaults/main.yml
+++ b/ansible/roles/bootstrap/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+# Official Debian repo. armhf ARMv7+
+jessie_backports_repo: deb http://httpredir.debian.org/debian jessie-backports main
+
+# Debian signing keys. Used for Debian and Armbian
+jessie_backports_signing_keys:
+  - 7638D0442B90D010
+  - 8B48AD6246925553
+

--- a/ansible/roles/bootstrap/tasks/main.yml
+++ b/ansible/roles/bootstrap/tasks/main.yml
@@ -7,8 +7,8 @@
     state: present
   when: ansible_lsb["id"] == "Debian"
 
-# Backports repo is used by Debian and Raspbian
-- name: Add debian signing keys, necessary for backports repo
+# Debian-provided backports repo is used by Debian and Armbian
+- name: Add Debian signing keys, to allow Debian backports repo
   apt_key:
     keyserver: hkp://keyserver.ubuntu.com:80
     state: present
@@ -16,17 +16,34 @@
   with_items:
     - 7638D0442B90D010
     - 8B48AD6246925553
+  when: ansible_lsb["id"] != "Raspbian"
+
+# No Debian armhf backports repo exists that runs on ARMv6 so we have our
+#  own for the packages that we require
+- name: Add ConnectBox signing key, to allow ConnectBox backports repo
+  apt_key:
+    url: https://eisbox.net/downloads/connectbox/repo/apt/conf/92F3A749.gpg.key
+    state: present
+  when: ansible_lsb["id"] == "Raspbian"
 
 - name: Populate apt cache to avoid problems when loading jessie backport repo
   apt:
     update-cache: yes
 
-# Backports repo is used by Debian and Raspbian
-- name: Enable Jessie backport repo
+- name: Enable Debian-provided Jessie backport repo (for Debian and Armbian)
   apt_repository:
-    repo: deb http://httpredir.debian.org/debian jessie-backports main contrib non-free
-    filename: jessie-backports
+    repo: deb http://httpredir.debian.org/debian jessie-backports main
+    filename: debian-jessie-backports
     state: present
+  when: ansible_lsb["id"] != "Raspbian"
+
+# Connectbox-provided backports repo for Raspbian
+- name: Enable Connectbox-provided Jessie backport repo for Raspbian
+  apt_repository:
+    repo: deb https://eisbox.net/downloads/connectbox/repo jessie-backports main
+    filename: connectbox-jessie-backports
+    state: present
+  when: ansible_lsb["id"] == "Raspbian"
 
 - name: Populate apt cache now that repos are loaded
   apt:

--- a/ansible/roles/bootstrap/tasks/main.yml
+++ b/ansible/roles/bootstrap/tasks/main.yml
@@ -7,43 +7,22 @@
     state: present
   when: ansible_lsb["id"] == "Debian"
 
-# Debian-provided backports repo is used by Debian and Armbian
-- name: Add Debian signing keys, to allow Debian backports repo
+- name: Add signing keys for jessie backports repo
   apt_key:
     keyserver: hkp://keyserver.ubuntu.com:80
     state: present
     id: "{{ item }}"
-  with_items:
-    - 7638D0442B90D010
-    - 8B48AD6246925553
-  when: ansible_lsb["id"] != "Raspbian"
-
-# No Debian armhf backports repo exists that runs on ARMv6 so we have our
-#  own for the packages that we require
-- name: Add ConnectBox signing key, to allow ConnectBox backports repo
-  apt_key:
-    url: https://eisbox.net/downloads/connectbox/repo/apt/conf/92F3A749.gpg.key
-    state: present
-  when: ansible_lsb["id"] == "Raspbian"
+  with_items: "{{ jessie_backports_signing_keys }}"
 
 - name: Populate apt cache to avoid problems when loading jessie backport repo
   apt:
     update-cache: yes
 
-- name: Enable Debian-provided Jessie backport repo (for Debian and Armbian)
+- name: Enable Jessie backport repo
   apt_repository:
-    repo: deb http://httpredir.debian.org/debian jessie-backports main
-    filename: debian-jessie-backports
+    repo: "{{ jessie_backports_repo }}"
+    filename: jessie-backports
     state: present
-  when: ansible_lsb["id"] != "Raspbian"
-
-# Connectbox-provided backports repo for Raspbian
-- name: Enable Connectbox-provided Jessie backport repo for Raspbian
-  apt_repository:
-    repo: deb https://eisbox.net/downloads/connectbox/repo jessie-backports main
-    filename: connectbox-jessie-backports
-    state: present
-  when: ansible_lsb["id"] == "Raspbian"
 
 - name: Populate apt cache now that repos are loaded
   apt:


### PR DESCRIPTION
The Debian Jessie-backports repo is armhf but compilied for ARMv7+ and
is unusable on the Pi Zero family so we introduce a repo that we
manage that provides just the packages we need from jessie-backports
compiled with the Raspbian toolchain as armhf for ARMv6+