### PR TITLE
Fix MacOS Yosemite captive portal behaviour

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -26,15 +26,25 @@ nginx_vhosts:
     server_name: "_"
     extra_parameters: |
       rewrite_log on;
-      # Simulate internet access for iOS and MacOSX so we can exit
-      #  their captive portal browser.
-      #  See: https://forum.piratebox.cc/read.php?9,8927
-      if ($http_user_agent ~ CaptiveNetworkSupport) {
-        rewrite /.* /success.html;
-      }
+      # Simulate internet access for iOS and MacOSX pre-yosemite so we
+      #  can exit their captive portal browser.
+      # See: https://forum.piratebox.cc/read.php?9,8927
+      # No need to check for user agent, because the default server is not
+      #  a part of serving the connectbox interface, so we don't need to avoid
+      #  name clashes.
       location /success.html {
         root "{{ connectbox_default_content_root }}";
       }
+      # Simulate internet access for MacOSX Yosemite and later, so we
+      #  can exit their captive portal browser
+      # See: https://apple.stackexchange.com/questions/45418/how-to-automatically-login-to-captive-portals-on-os-x#
+      # No need to check for user agent, because the default server is not
+      #  a part of serving the connectbox interface, so we don't need to avoid
+      #  name clashes.
+      location /hotspot-detect.html {
+        root "{{ connectbox_default_content_root }}";
+      }
+
       # Simulate internet access for Android so we can exit their
       #  captive portal.
       #  See: https://www.chromium.org/chromium-os/chromiumos-design-docs/network-portal-detection

--- a/ansible/roles/webserver-content/files/hotspot-detect.html
+++ b/ansible/roles/webserver-content/files/hotspot-detect.html
@@ -1,0 +1,9 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2//EN">
+<HTML>
+<HEAD>
+    <TITLE>Success</TITLE>
+</HEAD>
+<BODY>
+Success
+</BODY>
+</HTML>

--- a/ansible/roles/webserver-content/tasks/main.yml
+++ b/ansible/roles/webserver-content/tasks/main.yml
@@ -37,6 +37,11 @@
     src: success.html
     dest: "{{ connectbox_default_content_root }}"
 
+- name: Copy MacOS Yosemite and later captive portal response page
+  copy:
+    src: hotspot-detect.html
+    dest: "{{ connectbox_default_content_root }}"
+
 - name: Copy Amazon Fire OS captive portal response page
   copy:
     src: wifistub.html

--- a/tests/test_connectbox_static.py
+++ b/tests/test_connectbox_static.py
@@ -56,15 +56,20 @@ class ConnectBoxBasicTestCase(unittest.TestCase):
         # Strictly this should be requesting an Apple page, but DNS.
         # See comments on testAndroidCaptivePortalResponse below
         headers = requests.utils.default_headers()
-        # MacOS and iOS send something of this form
+        # iOS and MacOS pre-Yosemite send something of this form
         headers.update({"User-Agent": "CaptiveNetworkSupport-346 wispr"})
-        r = requests.get("http://%s/" % (getTestTarget(),), headers=headers)
+        r = requests.get("http://%s/success.html" %
+                         (getTestTarget(),), headers=headers)
         self.assertIn("<BODY>\nSuccess\n</BODY>", r.text)
 
-    def testIOSCaptivePortalResponseForNonIOS(self):
-        """Do not return the success.html page for normal root requests"""
-        r = requests.get("http://%s/" % (getTestTarget(),))
-        self.assertNotIn("<BODY>\nSuccess\n</BODY>", r.text)
+    def testYosemiteCaptivePortalResponseForYosemite(self):
+        """Return the hotspot-detect.html page to bypass Yosemite login"""
+        headers = requests.utils.default_headers()
+        # MacOS Yosemite and later send something of this form
+        headers.update({"User-Agent": "CaptiveNetworkSupport-346 wispr"})
+        r = requests.get("http://%s/hotspot-detect.html" %
+                         (getTestTarget(),), headers=headers)
+        self.assertIn("<BODY>\nSuccess\n</BODY>", r.text)
 
     def testAndroidCaptivePortalResponse(self):
         """Return a 204 status code to bypass Android captive portal login"""


### PR DESCRIPTION
Yosemite and later have a different captive portal check to their
older MacOS brethren, so we need to add support for it.

This removes some user-agent logic from the nginx default server
that is no longer necessary. Previously the default server and the
connectbox server stanzas were combined, so we wanted to check the
useragent before responding with the magic captive portal responses
but now that it's separate, we don't have any risk of clashing with
a legit connectbox content request. This means we don't need the
user agent check. This meant that we could remove a negative test,
though we also added a test for Yosemite captive portal behaviour.