### PR TITLE
Create 10MB and 100MB test files in sample-content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ instead indentifies releases by release date.
 
 ## Unreleased
 
+- Added creation of a 10MB and 100MB test file to help with throughput
+  testing, when sample content is installed
 - Added Captive Portal Manager that causes the operating system captive
   portal agent on iOS 9+ and MacOS 10.10+ to display a link or reference
   to the ConnectBox front page.

--- a/ansible/roles/sample-content/tasks/main.yml
+++ b/ansible/roles/sample-content/tasks/main.yml
@@ -10,6 +10,21 @@
   - name: Place sample content at USB drive location
     command: rsync -a /tmp/connectbox-sample-content/content/ {{ connectbox_usb_files_root }}
 
+  - name: Create throughput-test directory
+    file:
+      dest: "{{ connectbox_usb_files_root }}/throughput-test"
+      state: directory
+
+  - name: Create 10MB throughput-test file
+    command: "dd if=/dev/urandom of={{ connectbox_usb_files_root }}/throughput-test/10MB.bin bs=1M count=10"
+    args:
+      creates: "{{ connectbox_usb_files_root }}/throughput-test/10MB.bin"
+
+  - name: Create 100MB throughput-test file
+    command: "dd if=/dev/urandom of={{ connectbox_usb_files_root }}/throughput-test/100MB.bin bs=1M count=100"
+    args:
+      creates: "{{ connectbox_usb_files_root }}/throughput-test/100MB.bin"
+
   when: deploy_sample_content == True
 
 - block:


### PR DESCRIPTION
This is to help with throughput testing, and they are only created
when sample content is deployed