### PR TITLE
Access log analyzer integration

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -24,7 +24,7 @@ connectbox_log_dir: /var/log/connectbox
 connectbox_access_log: "{{ connectbox_log_dir }}/connectbox-access.log"
 connectbox_error_log:  "{{ connectbox_log_dir }}/connectbox-error.log"
 
-access_log_analyzer_repo: https://github.com/ConnectBox/access_log_analyzer.git
+access_log_analyzer_repo: https://github.com/ConnectBox/access-log-analyzer.git
 
 nginx_vhosts:
   - listen: "*:80 default_server"

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -20,6 +20,11 @@ connectbox_config_root: /etc/connectbox
 connectbox_usb_files_root: /media/usb0
 connectbox_admin_credentials: admin:$apr1$CBOXFOO2$usYeNWIKOX910UnI/jugh.
 connectbox_default_hostname: connectbox.local
+connectbox_log_dir: /var/log/connectbox
+connectbox_access_log: "{{ connectbox_log_dir }}/connectbox-access.log"
+connectbox_error_log:  "{{ connectbox_log_dir }}/connectbox-error.log"
+
+access_log_analyzer_repo: https://github.com/ConnectBox/access_log_analyzer.git
 
 nginx_vhosts:
   - listen: "*:80 default_server"
@@ -45,8 +50,8 @@ nginx_vhosts:
     index: index.html
     root: "{{ connectbox_default_content_root }}"
     error_page: "404 /index.html"
-    access_log: "/var/log/nginx/connectbox-access.log"
-    error_log: "/var/log/nginx/connectbox-error.log"
+    access_log: "{{ connectbox_access_log }}"
+    error_log: "{{ connectbox_error_log }}"
     extra_parameters: |
       rewrite_log on;
 

--- a/ansible/roles/connectbox-pi/tasks/main.yml
+++ b/ansible/roles/connectbox-pi/tasks/main.yml
@@ -89,31 +89,31 @@
       %_connectbox ALL=(ALL) NOPASSWD: /usr/local/connectbox/bin/
   notify: reload PHP
 
-- name: install access_log_analyzer
+- name: install access-log-analyzer
   git:
     repo: '{{access_log_analyzer_repo}}'
-    dest: /usr/local/access_log_analyzer
+    dest: /usr/local/access-log-analyzer
 
-- name: Make access_log_analyzer etc directory
+- name: Make access-log-analyzer etc directory
   file:
     state: directory
-    path: /usr/local/access_log_analyzer/etc
+    path: /usr/local/access-log-analyzer/etc
     owner: _connectbox
     group: _connectbox
     mode: 0755
 
-- name: Make access_log_analyzer var directory
+- name: Make access-log-analyzer var directory
   file:
     state: directory
-    path: /usr/local/access_log_analyzer/var
+    path: /usr/local/access-log-analyzer/var
     owner: _connectbox
     group: _connectbox
     mode: 0755
 
-- name: Make access_log_analyzer config overrides
+- name: Make access-log-analyzer config overrides
   template:
-    src: access_log_analyzer.conf.j2
-    dest: /usr/local/access_log_analyzer/etc/access_log_analyzer.conf
+    src: access-log-analyzer.conf.j2
+    dest: /usr/local/access-log-analyzer/etc/access-log-analyzer.conf
     backup: yes
     owner: _connectbox
     group: _connectbox

--- a/ansible/roles/connectbox-pi/tasks/main.yml
+++ b/ansible/roles/connectbox-pi/tasks/main.yml
@@ -122,15 +122,15 @@
 - name: Make hourly logrotate config
   template:
     src: logrotate.hourly.conf.j2
-    dest: /usr/local/access_log_analyzer/etc/logrotate.hourly.conf
+    dest: /etc/logrotate.hourly.conf
     backup: yes
-    owner: _connectbox
-    group: _connectbox
+    owner: root
+    group: root
     mode: 0644
 
 - name: Configure hourly logrotate for connectbox access logrotate
   copy:
-    content: "/usr/sbin/logrotate /usr/local/access_log_analyzer/etc/logrotate.hourly.conf"
+    content: "/usr/sbin/logrotate /etc/logrotate.hourly.conf"
     dest: "/etc/cron.hourly/logrotate.hourly"
 
 # If the system is updated before any iptables modules are loaded

--- a/ansible/roles/connectbox-pi/tasks/main.yml
+++ b/ansible/roles/connectbox-pi/tasks/main.yml
@@ -56,6 +56,15 @@
     group: _connectbox
     mode: 0755
 
+- name: Make logs directory
+  file:
+    state: directory
+    path: "{{ connectbox_log_dir }}"
+    owner: _connectbox
+    group: _connectbox
+    recurse: yes
+    mode: 0755
+
 - name: Copy connectbox scripts
   copy:
     src: ../scripts/
@@ -79,6 +88,50 @@
     block: |
       %_connectbox ALL=(ALL) NOPASSWD: /usr/local/connectbox/bin/
   notify: reload PHP
+
+- name: install access_log_analyzer
+  git:
+    repo: '{{access_log_analyzer_repo}}'
+    dest: /usr/local/access_log_analyzer
+
+- name: Make access_log_analyzer etc directory
+  file:
+    state: directory
+    path: /usr/local/access_log_analyzer/etc
+    owner: _connectbox
+    group: _connectbox
+    mode: 0755
+
+- name: Make access_log_analyzer var directory
+  file:
+    state: directory
+    path: /usr/local/access_log_analyzer/var
+    owner: _connectbox
+    group: _connectbox
+    mode: 0755
+
+- name: Make access_log_analyzer config overrides
+  template:
+    src: access_log_analyzer.conf.j2
+    dest: /usr/local/access_log_analyzer/etc/access_log_analyzer.conf
+    backup: yes
+    owner: _connectbox
+    group: _connectbox
+    mode: 0644
+
+- name: Make hourly logrotate config
+  template:
+    src: logrotate.hourly.conf.j2
+    dest: /usr/local/access_log_analyzer/etc/logrotate.hourly.conf
+    backup: yes
+    owner: _connectbox
+    group: _connectbox
+    mode: 0644
+
+- name: Configure hourly logrotate for connectbox access logrotate
+  copy:
+    content: "/usr/sbin/logrotate /usr/local/access_log_analyzer/etc/logrotate.hourly.conf"
+    dest: "/etc/cron.hourly/logrotate.hourly"
 
 # If the system is updated before any iptables modules are loaded
 #  the system can't find the modules and iptables rules can't be

--- a/ansible/roles/connectbox-pi/tasks/main.yml
+++ b/ansible/roles/connectbox-pi/tasks/main.yml
@@ -130,8 +130,11 @@
 
 - name: Configure hourly logrotate for connectbox access logrotate
   copy:
-    content: "/usr/sbin/logrotate /etc/logrotate.hourly.conf"
-    dest: "/etc/cron.hourly/logrotate.hourly"
+    content: "#!/bin/sh\n/usr/sbin/logrotate /etc/logrotate.hourly.conf"
+    dest: "/etc/cron.hourly/logrotate-hourly"
+    mode: 0755
+    owner: root
+    group: root
 
 # If the system is updated before any iptables modules are loaded
 #  the system can't find the modules and iptables rules can't be

--- a/ansible/roles/connectbox-pi/templates/access-log-analyzer.conf.j2
+++ b/ansible/roles/connectbox-pi/templates/access-log-analyzer.conf.j2
@@ -1,6 +1,6 @@
 [main]
 # Directory to store the sqlite databases holding aggregated stats
-DATABASE_DIRECTORY: /usr/local/access_log_analyzer/var
+DATABASE_DIRECTORY: /usr/local/access-log-analyzer/var
 
 # Directory to write json stats files
 OUTPUT_DIRECTORY: /var/www/connectbox/connectbox_default

--- a/ansible/roles/connectbox-pi/templates/access_log_analyzer.conf.j2
+++ b/ansible/roles/connectbox-pi/templates/access_log_analyzer.conf.j2
@@ -1,0 +1,6 @@
+[main]
+# Directory to store the sqlite databases holding aggregated stats
+DATABASE_DIRECTORY: /usr/local/access_log_analyzer/var
+
+# Directory to write json stats files
+OUTPUT_DIRECTORY: /var/www/connectbox/connectbox_default

--- a/ansible/roles/connectbox-pi/templates/logrotate.hourly.conf.j2
+++ b/ansible/roles/connectbox-pi/templates/logrotate.hourly.conf.j2
@@ -1,0 +1,18 @@
+{{ connectbox_log_dir }}/*.log {
+        rotate 12
+        missingok
+        compress
+        delaycompress
+        sharedscripts
+        create 0640 www-data adm
+        notifempty
+        prerotate
+                if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
+                        run-parts /etc/logrotate.d/httpd-prerotate; \
+                fi \
+        endscript
+        postrotate
+                invoke-rc.d nginx rotate >/dev/null 2>&1
+                /usr/local/access_log_analyzer/bin/access-log-analyzer.sh --config /usr/local/access_log_analyzer/etc/access_log_analyzer.conf < {{ connectbox_access_log }}.1
+        Endscript
+}

--- a/ansible/roles/connectbox-pi/templates/logrotate.hourly.conf.j2
+++ b/ansible/roles/connectbox-pi/templates/logrotate.hourly.conf.j2
@@ -6,6 +6,7 @@
         sharedscripts
         create 0640 www-data adm
         notifempty
+        size 1k
         prerotate
                 if [ -d /etc/logrotate.d/httpd-prerotate ]; then \
                         run-parts /etc/logrotate.d/httpd-prerotate; \
@@ -13,6 +14,6 @@
         endscript
         postrotate
                 invoke-rc.d nginx rotate >/dev/null 2>&1
-                /usr/local/access_log_analyzer/bin/access-log-analyzer.sh --config /usr/local/access_log_analyzer/etc/access_log_analyzer.conf < {{ connectbox_access_log }}.1
-        Endscript
+                /usr/local/access_log_analyzer/bin/access-log-analyzer.sh --config /usr/local/access_log_analyzer/etc/access_log_analyzer.conf {{ connectbox_access_log }}.1
+        endscript
 }

--- a/ansible/roles/connectbox-pi/templates/logrotate.hourly.conf.j2
+++ b/ansible/roles/connectbox-pi/templates/logrotate.hourly.conf.j2
@@ -14,6 +14,6 @@
         endscript
         postrotate
                 invoke-rc.d nginx rotate >/dev/null 2>&1
-                /usr/local/access_log_analyzer/bin/access-log-analyzer.sh --config /usr/local/access_log_analyzer/etc/access_log_analyzer.conf {{ connectbox_access_log }}.1
+                /usr/local/access-log-analyzer/bin/access-log-analyzer.sh --config /usr/local/access-log-analyzer/etc/access-log-analyzer.conf {{ connectbox_access_log }}.1
         endscript
 }


### PR DESCRIPTION
Integrates access-log-analyzer script into connectbox-pi
Hooks into connectbox log rotate
Splits connectbox nginx access/error logs into a separate log directory to allow hourly policy to be applied
