### PR TITLE
Run CI on container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 before_cache:
 - rm -f $HOME/.cache/pip/log/debug.log
 install:
-- wget -O /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.8.2/terraform_0.8.2_linux_amd64.zip
+- wget -O /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.9.8/terraform_0.9.8_linux_amd64.zip
 - unzip /tmp/terraform.zip
 - export PATH=$PATH:$PWD
 - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 dist: trusty
-sudo: true
+sudo: false
 cache:
   directories:
   - "$HOME/.cache/pip"

--- a/ci/main.tf
+++ b/ci/main.tf
@@ -19,6 +19,18 @@ resource "aws_key_pair" "travis-ci-connectbox-20170126" {
 	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCpGLG32t7stqIIU1MiRWMSpb4Cm3iOSJCX+G6BtOLu5RwpVR8/fE/w0ZlVpu3CWTtYRohqVUNGew8g9uSdt6aR/i1G3vmp2eyrfkV/R/ITt2rM4zzl8yGc5N5rlLzvem36Q1Z77UEZqXBqDnbZIH4tZw3IzKpk0RB2anGSzQ2NYn2gzW63KU4RcQY9Fg6A45qC5CFa6beF9l5epHB2AsO2N7x8aoPnmdRC/5Qej5kIxIgscZd4JHq8q3gpBYVVAucCp7Xmp3jiFLAvYAdVbTeIymDaWCvhAGTpweWod7Nu/sMUJ2l0IP9hVkd/ToapPOm3I1W+4rRjItbHK4BZsKYX"
 }
 
+data "aws_route53_zone" "selected" {
+  name         = "connectbox.org."
+}
+
+resource "aws_route53_record" "debian" {
+  zone_id = "${data.aws_route53_zone.selected.zone_id}"
+  name    = "debian.ci.${data.aws_route53_zone.selected.name}"
+  type    = "A"
+  ttl     = "1"
+  records = ["${aws_instance.connectbox-debian-server.public_ip}"]
+}
+
 # Shared by all travis-ci jobs
 resource "aws_vpc" "default" {
 	cidr_block = "${var.default_vpc_cidr}"

--- a/ci/main.tf
+++ b/ci/main.tf
@@ -131,9 +131,9 @@ resource "aws_network_interface" "client-facing-server" {
 	subnet_id = "${aws_subnet.client-facing-subnet.id}"
 	# AWS reserves the bottom four addresses in each subnet
 	#  so this is the lowest available
-	private_ips = ["${var.server_client_facing_ip}"]
+	private_ips = ["${var.debian_server_client_facing_ip}"]
 	attachment {
-		instance = "${aws_instance.connectbox-server.id}"
+		instance = "${aws_instance.connectbox-debian-server.id}"
 		device_index = 1
 	}
 	tags {
@@ -151,7 +151,7 @@ resource "aws_network_interface" "client-facing-server" {
 #	private_ips = ["10.0.1.5"]
 #	security_groups = ["${aws_security_group.default.id}"]
 #	attachment {
-#		instance = "${aws_instance.connectbox-server.id}"
+#		instance = "${aws_instance.connectbox-debian-server.id}"
 #		device_index = 1
 #	}
 #	tags {
@@ -162,14 +162,14 @@ resource "aws_network_interface" "client-facing-server" {
 #	}
 #}
 
-resource "aws_instance" "connectbox-server" {
+resource "aws_instance" "connectbox-debian-server" {
 	ami = "${lookup(var.amis, var.region)}"
 	instance_type = "${var.instance_type}"
 	key_name = "travis-ci-connectbox-20170126"
 	subnet_id = "${aws_subnet.default.id}"
 	vpc_security_group_ids = ["${aws_security_group.default.id}"]
 	tags {
-		Name = "connectbox-server"
+		Name = "connectbox-debian-server"
 		project = "connectbox"
 		lifecycle = "ci"
 		creator = "terraform"

--- a/ci/outputs.tf
+++ b/ci/outputs.tf
@@ -1,3 +1,3 @@
-output "connectbox-server-public-ip" {
-	value = "${aws_instance.connectbox-server.public_ip}"
+output "connectbox-debian-server-public-ip" {
+	value = "${aws_instance.connectbox-debian-server.public_ip}"
 }

--- a/ci/script_run_on_non_pull_requests.sh
+++ b/ci/script_run_on_non_pull_requests.sh
@@ -6,31 +6,29 @@
 # Makes no assumptions about working directory on entry, or the working
 #  directory left for subsequent scripts
 
-# Terraform output variables that define endpoints we'll sshe to
-PROVISIONED_TARGET_IP_VARIABLES="connectbox-debian-server-public-ip";
+# Each of these must be provisioned by terraform
+PROVISIONED_INSTANCE_NAMES="debian.ci.connectbox.org";
 
 # Servers should take 3 minutes max to become accessible over ssh, and as
 #  we wait for 1 second between attempts, this is our max attempt count
 MAX_SSH_CONNECT_ATTEMPTS=180;
 
 setup_and_verify_infra( ) {
-  # Expects arg of PROVISIONED_TARGET_IP_VARIABLES
+  # Expects arg of PROVISIONED_INSTANCE_NAMES
   # Make sure we don't have an inventory file, as we're going to append to it
   #  as we run this function.
   rm -f inventory;
   terraform apply;
 
-  for target_host_var in $1; do
+  for target_host in $1; do
     conn_attempt_count=0;
-    target_host=$(terraform output $target_host_var);
-
     # Wait for ssh to become available on the target host
     echo -n "Waiting for ssh to become available on $target_host "
     while ! (ssh -o ConnectTimeout=2 -o StrictHostKeyChecking=no -i $PEM_OUT admin@$target_host true 2> /dev/null); do
       if [ $conn_attempt_count -ge $MAX_SSH_CONNECT_ATTEMPTS ]; then
 	# Something has gone wrong. Bail (don't even attempt to connect to
 	#  any other hosts provisioned in the same terraform apply).
-	echo " unable to connect in $conn_attempt_count attempts.";
+	echo " unable to connect to $target_host in $conn_attempt_count attempts.";
 	return 1;
       fi
       echo -n ".";
@@ -39,9 +37,9 @@ setup_and_verify_infra( ) {
     done
     echo "OK";
     # Specify developer mode so the machine isn't locked down (we need access
-    #  (to run the tests)
+    #  to run the tests)
     echo "Adding $target_host to inventory";
-    echo "$target_host developer_mode=True ansible_ssh_user=admin ansible_ssh_private_key_file=$PEM_OUT" > inventory;
+    echo "$target_host developer_mode=True ansible_ssh_user=admin ansible_ssh_private_key_file=$PEM_OUT connectbox_default_hostname=debian.ci.connectbox.org" >> inventory;
   done
 
   echo "Inventory follows:";
@@ -60,12 +58,12 @@ openssl aes-256-cbc -K $encrypted_6b05639713bb_key -iv $encrypted_6b05639713bb_i
 # Run CI build on AWS. This uses protected variables
 cd $TRAVIS_BUILD_DIR/ci;
 
-setup_and_verify_infra $PROVISIONED_TARGET_IP_VARIABLES;
+setup_and_verify_infra $PROVISIONED_INSTANCE_NAMES;
 if [ $? -ne 0 ]; then
   # Try again.
   echo "Tearing down freshly provisioned infrastructure and trying again.";
   terraform destroy --force;
-  setup_and_verify_infra $PROVISIONED_TARGET_IP_VARIABLES;
+  setup_and_verify_infra $PROVISIONED_INSTANCE_NAMES;
   if [ $? -ne 0 ]; then
     # Something is seriously wrong, and we should bail
     echo "Unable to connect to AWS infrastructure after two attempts. Tearing down freshly provisioned infrastructure and bailing."
@@ -90,8 +88,7 @@ else
 fi
 
 
-# Tell the test running host how to find the connectbox by name
-# Use tee rather than trying to redirect using sudo
-printf "\n%s connectbox.local" ${target_host} | sudo tee -a /etc/hosts > /dev/null
-# Run web/selenium tests
-TEST_IP=$target_host python -m unittest discover ../tests
+# Run web/selenium tests for each host
+for target_host in $PROVISIONED_INSTANCE_NAMES; do
+  TEST_IP=$(dig +short $target_host) python -m unittest discover ../tests;
+done

--- a/ci/script_run_on_non_pull_requests.sh
+++ b/ci/script_run_on_non_pull_requests.sh
@@ -7,7 +7,7 @@
 #  directory left for subsequent scripts
 
 # Terraform output variables that define endpoints we'll sshe to
-PROVISIONED_TARGET_IP_VARIABLES="connectbox-server-public-ip";
+PROVISIONED_TARGET_IP_VARIABLES="connectbox-debian-server-public-ip";
 
 # Servers should take 3 minutes max to become accessible over ssh, and as
 #  we wait for 1 second between attempts, this is our max attempt count

--- a/ci/variables.tf
+++ b/ci/variables.tf
@@ -1,4 +1,5 @@
 variable "region" { default = "us-west-2" }
+#variable "region" { default = "ap-southeast-2" }
 
 # Seemingly required so subnets are not necessarily created in the same AZ as
 #  the network interfaces
@@ -26,4 +27,4 @@ variable "default_vpc_cidr" { default = "10.0.0.0/16" }
 variable "default_subnet_cidr" { default = "10.0.1.0/24" }
 variable "client_facing_subnet_cidr" { default = "10.0.2.0/24" }
 
-variable "server_client_facing_ip" { default = "10.0.2.5" }
+variable "debian_server_client_facing_ip" { default = "10.0.2.5" }


### PR DESCRIPTION
Auto-create DNS records for CI test instance, which avoids munging /etc/hosts on the build machine. Prep for Ubuntu CI machine.