### PR TITLE
Correct rt5372 ht_capab parameters

### DIFF
--- a/ansible/group_vars/rt5372
+++ b/ansible/group_vars/rt5372
@@ -1,2 +1,2 @@
 ieee80211n_enabled: 1
-wireless_adapter_capabilities: "[HT20][HT40+][SHORT-GI-20][SHORT-GI-40][MAX-AMSDU-7935][DDDS_CCK-40]"
+wireless_adapter_capabilities: "[HT20][HT40+][SHORT-GI-20][SHORT-GI-40][TX-STBC][RX-STBC12]"

--- a/ansible/group_vars/rtl8192cu
+++ b/ansible/group_vars/rtl8192cu
@@ -1,0 +1,2 @@
+ieee80211n_enabled: 1
+wireless_adapter_capabilities: "[HT20][HT40+][SHORT-GI-20][SHORT-GI-40][MAX-AMSDU-7935][DDDS_CCK-40]"


### PR DESCRIPTION
I incorrectly added rtl8192cu params as rt5372. Corrected now. Related to #120 