### PR TITLE
Set the locale in the admin api

### DIFF
--- a/html/admin/api.php
+++ b/html/admin/api.php
@@ -1,4 +1,5 @@
 <?php
+setlocale(LC_CTYPE, "en_US.UTF-8");
 header('Content-Type: application/json; charset=UTF8');
 define("_CMD", "sudo /usr/local/connectbox/bin/ConnectBoxManage.sh");
 $method = $_SERVER['REQUEST_METHOD'];


### PR DESCRIPTION
Armbian and Raspbian set the locale appropriately, but the official
Ubuntu AMI that we'll use in #131 does not, which means that
escapeshellcmd strips out unicode characters, which is problematic
given we explicitly test setting SSIDs containing unicode strings (specifically, test32CharacterUnicodeSSIDSet is failing on the Ubuntu AMI without this change)

I don't think it's a problem to set this in the script, given we
control the connectbox environment and are shipping the device
with LC_CTYPE="en_US.UTF-8"  (it'd be LC_CTYPE="en_GB.UTF-8" if we
shipped a raspbian device), and both of those locales would allow
unicode characters through.

I don’t really know what I’m doing with PHP, so please correct me if this is inappropriate.