### PR TITLE
Provision 512mb VMs. Swap host+domain for VMs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,20 +7,20 @@ Vagrant.configure(2) do |config|
   config.vm.box = ""
 
   config.vm.provider "virtualbox" do |vb|
-    vb.memory = "1024"
+    vb.memory = "512"
   end
 
   # Debian Jessie
   config.vm.define "debian" do |debian|
     debian.vm.box = "debian/jessie64"
     debian.vm.network "private_network", ip: "172.28.128.3"
-    debian.vm.post_up_message = "ConnectBox (Debian Jessie) provisioned in developer mode. IP: 172.28.128.3, hostname: connectbox.debian-vagrant. You probably want '172.28.128.3 connectbox.debian-vagrant' in /etc/hosts"
+    debian.vm.post_up_message = "ConnectBox (Debian Jessie) provisioned in developer mode. IP: 172.28.128.3, hostname: debian-vagrant.connectbox. You probably want '172.28.128.3 debian-vagrant.connectbox' in /etc/hosts"
 
     debian.vm.provision "ansible" do |ansible|
       ansible.playbook = "ansible/site.yml"
       ansible.host_vars = {
 	      "debian" => {
-          "connectbox_default_hostname": "connectbox.debian-vagrant",
+          "connectbox_default_hostname": "debian-vagrant.connectbox",
           "developer_mode": true,
 	}
       }
@@ -34,13 +34,13 @@ Vagrant.configure(2) do |config|
     #  https://bugs.launchpad.net/cloud-images/+bug/1569237
     ubuntu.vm.box = "bento/ubuntu-16.04"
     ubuntu.vm.network "private_network", ip: "172.28.128.4"
-    ubuntu.vm.post_up_message = "ConnectBox (Ubuntu Xenial) provisioned in developer mode. IP: 172.28.128.4, hostname: connectbox.ubuntu-vagrant. You probably want '172.28.128.4 connectbox.ubuntu-vagrant' in /etc/hosts"
+    ubuntu.vm.post_up_message = "ConnectBox (Ubuntu Xenial) provisioned in developer mode. IP: 172.28.128.4, hostname: ubuntu-vagrant.connectbox. You probably want '172.28.128.4 ubuntu-vagrant.connectbox' in /etc/hosts"
 
     ubuntu.vm.provision "ansible" do |ansible|
       ansible.playbook = "ansible/site.yml"
       ansible.host_vars = {
         "ubuntu" => {
-          "connectbox_default_hostname": "connectbox.ubuntu-vagrant",
+          "connectbox_default_hostname": "ubuntu-vagrant.connectbox",
           "developer_mode": true,
 	}
       }


### PR DESCRIPTION
* Reduce VM memory because our target deployments have less RAM.
* Swap host and domain for provisioned VMs to make it easier to manage a DNS domain with multiple connectboxes (e.g. rpi3.connectbox, ubuntu-vagrant.connectbox, neo.connectbox)

Have confirmed that the reduced memory doesn’t impact performance.
Wanted to check with you re: the DNS change in case it would cause a problem for you.
