### PR TITLE
Fix dnsmasq startup ordering

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -6,6 +6,16 @@
 # Parameterised to allow overriding during CI builds, where we want to
 #  test some client-facing capabilities but do not have a wifi interface
 client_facing_if: "wlan0"
+
+# Client facing if stuff is defined here because we have a circular dependency
+# in that dns-dhcp depends
+#  on the IP address for wlan0 that's defined in the network-interfaces role
+#  but network-interfaces needs dnsmasq to be installed (which is done by the
+#  dns-dhcp role)
+client_facing_if_ip_address: 10.129.0.1
+client_facing_if_netmask: 255.255.255.0
+client_facing_if_network_cidr: 10.129.0.0/24
+
 # Unset country code. Operators should override with their country, based
 #  on the entries in the following file:
 # https://git.kernel.org/cgit/linux/kernel/git/sforshee/wireless-regdb.git/tree/db.txt

--- a/ansible/roles/connectbox-pi/meta/main.yml
+++ b/ansible/roles/connectbox-pi/meta/main.yml
@@ -4,6 +4,8 @@
 dependencies:
   - bootstrap
   - dns-dhcp
+  - network-interfaces
+  - wifi-ap
   - mikegleasonjr.firewall
   - nginx
   - webserver-content

--- a/ansible/roles/dns-dhcp/handlers/main.yml
+++ b/ansible/roles/dns-dhcp/handlers/main.yml
@@ -1,8 +1,0 @@
----
-# A reload with the current ordering, when installed on a vanilla system
-# results in a dnsmasq that doesn't offer DHCP addresses. A restart seems to
-# fix that but it would be nice to know why a reload was insufficient
-- name: Restart dnsmasq
-  service:
-    name: dnsmasq
-    state: restarted

--- a/ansible/roles/dns-dhcp/meta/main.yml
+++ b/ansible/roles/dns-dhcp/meta/main.yml
@@ -1,5 +1,1 @@
 ---
-dependencies:
-  - network-interfaces
-  - wifi-ap
-

--- a/ansible/roles/dns-dhcp/tasks/main.yml
+++ b/ansible/roles/dns-dhcp/tasks/main.yml
@@ -6,7 +6,6 @@
     owner: root
     group: root
     mode: 0644
-  notify: Restart dnsmasq
 
 # Note that the handler must do a restart instead of a reload as some of
 #  these defaults are only read at startup
@@ -14,7 +13,6 @@
   copy:
     src: etc_default_dnsmasq
     dest: /etc/default/dnsmasq
-  notify: Restart dnsmasq
 
 # This is necessary because nginx redirects to the hostname, but the hostname
 #  is listed in /etc/hosts and associated with 127.0.0.1 (so dnsmasq uses it
@@ -39,8 +37,8 @@
     name: dnsmasq
     state: present
 
-- name: Start and enable dnsmasq
+- name: Stop and disable dnsmasq given it is managed as a pre-down post-up task for wlan0
   service:
     name: dnsmasq
-    enabled: yes
-    state: started
+    enabled: no
+    state: stopped

--- a/ansible/roles/network-interfaces/defaults/main.yml
+++ b/ansible/roles/network-interfaces/defaults/main.yml
@@ -1,5 +1,2 @@
 ---
-client_facing_if_ip_address: 10.129.0.1
-client_facing_if_netmask: 255.255.255.0
-client_facing_if_network_cidr: 10.129.0.0/24
 hostname: connectbox.local

--- a/ansible/roles/network-interfaces/templates/etc_network_interfaces.j2
+++ b/ansible/roles/network-interfaces/templates/etc_network_interfaces.j2
@@ -15,3 +15,9 @@ iface {{ client_facing_if }} inet static
     address {{ client_facing_if_ip_address }}
     netmask {{ client_facing_if_netmask }}
     hostapd /etc/hostapd/hostapd.conf
+    # dnsmasq does not always answer DHCP requests after wifi unplug/replug
+    #  so we manage it's start and stop here. We always expect wlan0 to be
+    #  running on a functioning system, so this dependency on wlan0 is not
+    #  a problem.
+    post-up systemctl start dnsmasq
+    pre-down systemctl stop dnsmasq


### PR DESCRIPTION
dnsmasq is now started (and stopped) as a part of the ifup/ifdown
sequence for wlan0 based on solution by @matheweis 

Fixes #121 