### PR TITLE
Filter identified system files from view in icon only interface

### DIFF
--- a/html/client/config/default.json
+++ b/html/client/config/default.json
@@ -8,7 +8,12 @@
     "icon_prefix": "_icon_",
     "stats_file": "stats.top10.json",
     "system_files": [
-        "System Volume Information", "AUTORUN.INF*", "AUTORUN.INF", "autorun.inf", "Autorun.inf", ".DS_Store"
+      "System Volume Information",
+      "AUTORUN.INF*",
+      "AUTORUN.INF",
+      "autorun.inf",
+      "Autorun.inf",
+      ".DS_Store"
     ]
   }
 }

--- a/html/client/config/default.json
+++ b/html/client/config/default.json
@@ -8,7 +8,7 @@
     "icon_prefix": "_icon_",
     "stats_file": "stats.top10.json",
     "system_files": [
-        "System Volume Information", "AUTORUN.INF*", "AUTORUN.INF", ".DS_Store"
+        "System Volume Information", "AUTORUN.INF*", "AUTORUN.INF", "autorun.inf", "Autorun.inf", ".DS_Store"
     ]
   }
 }

--- a/html/client/config/default.json
+++ b/html/client/config/default.json
@@ -6,6 +6,9 @@
     "tail_slash": true,
     "display_root_folder_names": true,
     "icon_prefix": "_icon_",
-    "stats_file": "stats.top10.json"
+    "stats_file": "stats.top10.json",
+    "system_files": [
+        "System Volume Information", "AUTORUN.INF*", ".DS_Store"
+    ]
   }
 }

--- a/html/client/config/default.json
+++ b/html/client/config/default.json
@@ -8,7 +8,7 @@
     "icon_prefix": "_icon_",
     "stats_file": "stats.top10.json",
     "system_files": [
-        "System Volume Information", "AUTORUN.INF*", ".DS_Store"
+        "System Volume Information", "AUTORUN.INF*", "AUTORUN.INF", ".DS_Store"
     ]
   }
 }

--- a/html/client/index.html
+++ b/html/client/index.html
@@ -291,6 +291,8 @@ angular.module('index', ['ng'])
                             if (f.name.startsWith(self.config.Client.icon_prefix)) {
                                 parse_ico_metadata(self.config.Client.icon_prefix, f.name, dirMap);
                                 return false;
+                            } else if (self.config.Client.system_files.indexOf(f.name) != -1) {
+                                return false;
                             } else {
                                 return true;
                             }


### PR DESCRIPTION
Note that I think unix hidden files (like .DS_Store) are already hidden, but adding it in anyway just in case.