### PR TITLE
Activate internal USB ports on NanoPi NEO

### DIFF
--- a/ansible/roles/bootstrap/tasks/main.yml
+++ b/ansible/roles/bootstrap/tasks/main.yml
@@ -13,6 +13,29 @@
   when: ansible_distribution == "Ubuntu" and ansible_virtualization_type == "NA"
   register: old_style_names
 
+- block:
+  - name: Create usbhost1 device tree overlay for NanoPi NEO internal USB port
+    shell: sed 's/hci0/hci1/g' /boot/dtb/overlay/sun8i-h3-usbhost0.dtbo > /boot/dtb/overlay/sun8i-h3-usbhost1.dtbo
+    args:
+      creates: /boot/dtb/overlay/sun8i-h3-usbhost1.dtbo
+      warn: False  # Can't use either lineinfile or template here
+
+  # will have problems if overlay lines are already present, but as that's not
+  #  something we see at the moment, we won't try to cater for it
+  - name: Activate all usbhost overlays on NanoPi NEO
+    lineinfile:
+      path: /boot/armbianEnv.txt
+      line: "overlays=usbhost0 usbhost1 usbhost2 usbhost3"
+      state: present
+    register: insert_usb_overlays
+
+  - name: Request reboot if usbhost overlays have been changed
+    fail:
+      msg: "The system must be rebooted to activate additional usb ports"
+    when: insert_usb_overlays.changed
+    tags: skip_ansible_lint
+  when: '"NanoPi NEO" in machine_type.stdout'
+
 - name: Request reboot if interface naming style has changed
   fail:
     msg: "The system must be rebooted to apply old-style interface names"

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -27,6 +27,16 @@
     - name: Include Armbian specific variables
       include_vars: "group_vars/armbian"
       when: armbian_file.stat.exists == True or armbian_release_file.stat.exists == True
+    # This is probably better implemented as an ansible plugin so we can support
+    #  machines with 3.x series kernels (armbian legacy)
+    # We will get errors when this file doesn't exist (3.x series kernels) so we
+    #  ignore errors. It's ok if this is unset because we're only looking for a
+    #  string inside the registered result.
+    - name: Register machine type
+      command: cat /sys/firmware/devicetree/base/model
+      register: machine_type
+      ignore_errors: yes
+      changed_when: False
   become: yes
   roles:
     - connectbox-pi


### PR DESCRIPTION
Also register a machine_type variable that contains the model of device
for machines running kernel 4.x (those that use fdt)

Fixes: #129 