### PR TITLE
Tell dnsmasq to be authoritative for it's dhcp ranges

### DIFF
--- a/ansible/roles/dns-dhcp/templates/etc_dnsmasq.conf.j2
+++ b/ansible/roles/dns-dhcp/templates/etc_dnsmasq.conf.j2
@@ -35,6 +35,9 @@ local-ttl=5
 quiet-dhcp
 quiet-dhcp6
 
+# Speed up DHCP by allowing it to reject unknown leases
+dhcp-authoritative
+
 # Don't keep a leasefile, as leases contain MAC addresses and they're
 #  potentially incriminating
 leasefile-ro


### PR DESCRIPTION
> For DHCPv4, it changes the behaviour from strict RFC compliance so that DHCP requests on unknown leases from unknown hosts are not ignored. This allows new hosts to get a lease without a tedious timeout under all circumstances. It also allows dnsmasq to rebuild its lease database without each client needing to reacquire a lease, if the database is lost.

From: http://www.thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html

All those things are good.