### PR TITLE
Only support 802.11n adapters

### DIFF
--- a/ansible/group_vars/ar9271
+++ b/ansible/group_vars/ar9271
@@ -1,3 +1,2 @@
 ---
-ieee80211n_enabled: 1
 wireless_adapter_capabilities: "[HT20][HT40+][SHORT-GI-20][SHORT-GI-40][RX-STBC1][DDDS_CCK-40]"

--- a/ansible/group_vars/pine64
+++ b/ansible/group_vars/pine64
@@ -1,4 +1,3 @@
 ---
-ieee80211n_enabled: 1
 # From: https://github.com/ConnectBox/connectbox-pi/wiki/Wireless-Benchmarking-with-ht_capab-settings
 wireless_adapter_capabilities: "[HT40][SHORT-GI-20][SHORT-GI-40][MAX-AMSDU-7935][DDDS_CCK-40]"

--- a/ansible/group_vars/raspberry_pi_3
+++ b/ansible/group_vars/raspberry_pi_3
@@ -1,5 +1,4 @@
 ---
-ieee80211n_enabled: 1
 # From: https://github.com/ConnectBox/connectbox-pi/wiki/Wireless-Benchmarking-with-ht_capab-settings
 wireless_adapter_capabilities: "[HT20][SHORT-GI-20][DDDS_CCK-40]"
 

--- a/ansible/group_vars/raspberry_pi_zero_w
+++ b/ansible/group_vars/raspberry_pi_zero_w
@@ -1,5 +1,4 @@
 ---
-ieee80211n_enabled: 1
 # From: https://github.com/ConnectBox/connectbox-pi/wiki/Wireless-Benchmarking-with-ht_capab-settings
 wireless_adapter_capabilities: "[HT20][SHORT-GI-20][DDDS_CCK-40]"
 

--- a/ansible/group_vars/rt5370
+++ b/ansible/group_vars/rt5370
@@ -1,3 +1,2 @@
 ---
-ieee80211n_enabled: 1
 wireless_adapter_capabilities: "[HT20][HT40+][SHORT-GI-20][SHORT-GI-40][RX-STBC1]"

--- a/ansible/group_vars/rt5372
+++ b/ansible/group_vars/rt5372
@@ -1,2 +1,2 @@
-ieee80211n_enabled: 1
+---
 wireless_adapter_capabilities: "[HT20][HT40+][SHORT-GI-20][SHORT-GI-40][TX-STBC][RX-STBC12]"

--- a/ansible/group_vars/rtl8192cu
+++ b/ansible/group_vars/rtl8192cu
@@ -1,2 +1,2 @@
-ieee80211n_enabled: 1
+---
 wireless_adapter_capabilities: "[HT20][HT40+][SHORT-GI-20][SHORT-GI-40][MAX-AMSDU-7935][DDDS_CCK-40]"

--- a/ansible/roles/wifi-ap/defaults/main.yml
+++ b/ansible/roles/wifi-ap/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 ssid: "ConnectBox - Free Media"
 wireless_channel: 1
-ieee80211n_enabled: 0
 # Sentinel used in hostapd.conf.j2 (see doco there)
 wireless_adapter_capabilities: __default__

--- a/ansible/roles/wifi-ap/templates/hostapd.conf.j2
+++ b/ansible/roles/wifi-ap/templates/hostapd.conf.j2
@@ -15,7 +15,7 @@ country_code={{ wireless_country_code }}
 
 # Enable 802.11n (requires hw_mode=g)
 hw_mode=g
-ieee80211n={{ ieee80211n_enabled }}
+ieee80211n=1
 
 # ACS is not supported on the brcmfmac driver (onboard wifi in rpi3)
 channel={{ wireless_channel }}


### PR DESCRIPTION
The choice to support 802.11g is a hangover from very early days. Remove the choice as we don’t need it.