### PR TITLE
Changed hostname from connectbox.local to connectbox

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -29,7 +29,7 @@ connectbox_captive_portal_virtualenv: "{{ connectbox_web_root }}/captive_portal_
 connectbox_config_root: /etc/connectbox
 connectbox_usb_files_root: /media/usb0
 connectbox_admin_credentials: admin:$apr1$CBOXFOO2$usYeNWIKOX910UnI/jugh.
-connectbox_default_hostname: connectbox.local
+connectbox_default_hostname: connectbox
 connectbox_log_dir: /var/log/connectbox
 connectbox_access_log: "{{ connectbox_log_dir }}/connectbox-access.log"
 connectbox_error_log:  "{{ connectbox_log_dir }}/connectbox-error.log"


### PR DESCRIPTION
Had an issue with connecting to Connectbox from Linux desktop (Ubuntu 16.04).  

Once the Linux desktop had connected to the connectbox wireless network, it was issued an IP address.  Opening a browser and typing in any URL did not return a webpage, and would result in a timeout.  

Further research (Wireshark) determined that the following was happening.  The Browser (Chrome or Firefox) was correctly looking up the hostname using DNS.  DNS returned the IP address of connectbox (10.129.0.1).  The browser requested page HTTP://10.129.0.1, and was given a HTTP redirect to HTTP://connectbox.local.  Linux believed that this hostname was local, so a request was sent out over port 5353 (mDNS) to find the IP address, and did not receive a response, since mDNS is not configured in Avahi.  The Browser would eventually just timeout.

By changing the hostname to "Connectbox", the Linux desktop does not use mDNS to try to resolve the hostname (only using DNS), and everything works correctly.