### PR TITLE
Fix #156 - Modify update logic to handle network changes

### DIFF
--- a/html/admin/css/style.css
+++ b/html/admin/css/style.css
@@ -8,6 +8,16 @@
     width: 350px;
 }
 
+.info #msg-title
+{
+    background-color: grey;
+    color: floralwhite;
+    padding: 5px;
+    -webkit-border-radius: 5;
+    -moz-border-radius: 5;
+    border-radius: 5px;
+}
+
 .error #msg-title
 {
     background-color: crimson;


### PR DESCRIPTION
On ssid update, the user is prompted to select the new ssid before continuing. A channel update will retry on error until the update is successful. The hostname dialog indicates the change was made and then redirects when the user clicks ok.