### PR TITLE
Set wifi regdomain from sniffed AP beacon frames

### DIFF
--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -16,11 +16,6 @@ client_facing_if_ip_address: 10.129.0.1
 client_facing_if_netmask: 255.255.0.0
 client_facing_if_network_cidr: 10.129.0.0/16
 
-# Unset country code. Operators should override with their country, based
-#  on the entries in the following file:
-# https://git.kernel.org/cgit/linux/kernel/git/sforshee/wireless-regdb.git/tree/db.txt
-wireless_country_code: "00"
-
 connectbox_web_root: /var/www/connectbox
 connectbox_default_content_root: "{{ connectbox_web_root }}/connectbox_default"
 connectbox_admin_root: "{{ connectbox_web_root }}/admin"

--- a/ansible/roles/network-interfaces/templates/etc_network_interfaces.j2
+++ b/ansible/roles/network-interfaces/templates/etc_network_interfaces.j2
@@ -15,6 +15,7 @@ iface {{ client_facing_if }} inet static
     address {{ client_facing_if_ip_address }}
     netmask {{ client_facing_if_netmask }}
     hostapd /etc/hostapd/hostapd.conf
+    pre-up /etc/hostapd/set_wifi_country_code.sh
     # dnsmasq does not always answer DHCP requests after wifi unplug/replug
     #  so we manage it's start and stop here. We always expect wlan0 to be
     #  running on a functioning system, so this dependency on wlan0 is not

--- a/ansible/roles/wifi-ap/defaults/main.yml
+++ b/ansible/roles/wifi-ap/defaults/main.yml
@@ -1,5 +1,10 @@
 ---
 ssid: "ConnectBox - Free Media"
 wireless_channel: 1
+# Only used as an override. Country code is automatically set when the
+#  wifi device comes up, and defaults to the world regulatory domain 00.
+#  To override, set an entry based on those in the following file:
+# https://git.kernel.org/cgit/linux/kernel/git/sforshee/wireless-regdb.git/tree/db.txt
+wireless_country_code: ""
 # rt5372
 wireless_adapter_capabilities: "[HT20][HT40+][SHORT-GI-20][SHORT-GI-40][TX-STBC][RX-STBC12]"

--- a/ansible/roles/wifi-ap/tasks/main.yml
+++ b/ansible/roles/wifi-ap/tasks/main.yml
@@ -13,6 +13,22 @@
     mode: 0644
   register: etc_hostapd_hostapd_conf
 
+- name: Copy script to set regulatory domain
+  template:
+    src: set_wifi_country_code.sh.j2
+    dest: /etc/hostapd/set_wifi_country_code.sh
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Populate /etc/default/crda with regulatory domain override
+  template:
+    src: etc_default_crda.j2
+    dest: /etc/default/crda
+    owner: root
+    group: root
+    mode: 0644
+
 # We're using the ifupdown method instead of the initscript method
 #  so this is just an ifdown and ifup operation rather than a
 #  service reload hostapd

--- a/ansible/roles/wifi-ap/templates/etc_default_crda.j2
+++ b/ansible/roles/wifi-ap/templates/etc_default_crda.j2
@@ -1,0 +1,11 @@
+# Set REGDOMAIN to a ISO/IEC 3166-1 alpha2 country code so that iw(8) may set
+# the initial regulatory domain setting for IEEE 802.11 devices which operate
+# on this system.
+#
+# Governments assert the right to regulate usage of radio spectrum within
+# their respective territories so make sure you select a ISO/IEC 3166-1 alpha2
+# country code suitable for your location or you may infringe on local
+# legislature. See `/usr/share/zoneinfo/zone.tab' for a table of timezone
+# descriptions containing ISO/IEC 3166-1 alpha2 country codes.
+
+REGDOMAIN={{ wireless_country_code }}

--- a/ansible/roles/wifi-ap/templates/hostapd.conf.j2
+++ b/ansible/roles/wifi-ap/templates/hostapd.conf.j2
@@ -11,7 +11,7 @@ ctrl_interface_group=0
 ssid={{ ssid }}
 utf8_ssid=1
 
-country_code={{ wireless_country_code }}
+country_code=00
 
 # Enable 802.11n (requires hw_mode=g)
 hw_mode=g

--- a/ansible/roles/wifi-ap/templates/set_wifi_country_code.sh.j2
+++ b/ansible/roles/wifi-ap/templates/set_wifi_country_code.sh.j2
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+TAG=$(basename $0);
+WIFI_INTERFACE={{ client_facing_if }};
+HOSTAPD_CONF=/etc/hostapd/hostapd.conf;
+CRDA_CONFIG=/etc/default/crda;
+
+current_hostapd_cc=$(awk -F= '$1 ~ /^country_code/ {print $2;}' ${HOSTAPD_CONF})
+
+# CRDA config sets REGDOMAIN. If that's set, then we treat that as a
+#  deliberate override.
+. ${CRDA_CONFIG};
+
+if [ -z "${REGDOMAIN}" ]; then
+	# No CRDA override. Let's scan surrounding networks and take the most
+	#  popular regulatory domain
+	ifconfig ${WIFI_INTERFACE} up;
+	ambient_cc=$(iw dev ${WIFI_INTERFACE} scan |
+		awk '$1 ~ /Country:/ { print $2;}' |
+		sort |
+		uniq -c |
+		sort -n |
+		tail -1 |
+		awk '{print $2;}');
+	# Leave things as you found them, like your parents said
+	ifconfig ${WIFI_INTERFACE} down;
+
+	# If we can't get any regulatory domains from surrounding networks
+	#  then we have no reason to change what's set in hostapd
+	if [ -z "${ambient_cc}" ]; then
+		new_cc=${current_hostapd_cc};
+	else
+		new_cc=${ambient_cc};
+	fi
+else
+	new_cc=${REGDOMAIN};
+fi
+
+if [ "${new_cc}" != "${current_hostapd_cc}" ]; then
+	logger -t ${TAG} "Setting hostapd country_code from ${current_hostapd_cc} to ${new_cc}";
+	sed -i 's/^country_code.*/country_code='${new_cc}'/' $HOSTAPD_CONF;
+fi

--- a/ansible/roles/wifi-ap/templates/set_wifi_country_code.sh.j2
+++ b/ansible/roles/wifi-ap/templates/set_wifi_country_code.sh.j2
@@ -6,6 +6,7 @@ HOSTAPD_CONF=/etc/hostapd/hostapd.conf;
 CRDA_CONFIG=/etc/default/crda;
 
 current_hostapd_cc=$(awk -F= '$1 ~ /^country_code/ {print $2;}' ${HOSTAPD_CONF})
+initial_wifi_interface_state=$(cat /sys/class/net/${WIFI_INTERFACE}/operstate);
 
 # CRDA config sets REGDOMAIN. If that's set, then we treat that as a
 #  deliberate override.
@@ -14,7 +15,10 @@ current_hostapd_cc=$(awk -F= '$1 ~ /^country_code/ {print $2;}' ${HOSTAPD_CONF})
 if [ -z "${REGDOMAIN}" ]; then
 	# No CRDA override. Let's scan surrounding networks and take the most
 	#  popular regulatory domain
-	ifconfig ${WIFI_INTERFACE} up;
+
+	if [ "$initial_wifi_interface_state" != "up" ]; then
+		ifconfig ${WIFI_INTERFACE} up;
+	fi
 	ambient_cc=$(iw dev ${WIFI_INTERFACE} scan |
 		awk '$1 ~ /Country:/ { print $2;}' |
 		sort |
@@ -23,7 +27,9 @@ if [ -z "${REGDOMAIN}" ]; then
 		tail -1 |
 		awk '{print $2;}');
 	# Leave things as you found them, like your parents said
-	ifconfig ${WIFI_INTERFACE} down;
+	if [ "$initial_wifi_interface_state" = "down" ]; then
+		ifconfig ${WIFI_INTERFACE} down;
+	fi
 
 	# If we can't get any regulatory domains from surrounding networks
 	#  then we have no reason to change what's set in hostapd


### PR DESCRIPTION
The world regulatory domain (00) is unnecessarily restrictive in
terms of channel selection and tx-power. We can infer the local
regulatory domain by looking at beacon frames from local access
points before bringing up the interface and hostapd.

An override is available by setting the REGDOMAIN in /etc/default/crda
(if ansible-playbook runs are involved, set wireless_country_code in
the ansible-playbook arguments)