### PR TITLE
Remove txpower menu entry from admin interface

### DIFF
--- a/html/admin/index.html
+++ b/html/admin/index.html
@@ -66,7 +66,6 @@
                 <li class="dropdown-header">Wireless Access Point</li>
                 <li><a href="#" id="menu_ssid">SSID</a></li>
                 <li><a href="#" id="menu_channel">Channel</a></li>
-                <li><a href="#" id="menu_txpower">TX Power</a></li>
               </ul>
             </li>
           </ul>


### PR DESCRIPTION
As our wifi interfaces run at max-power, as defined by the
regulatory domain, and there's no clear use-case for reducing
power, there's no need to expose setting txpower.

OK'ed by @geodirk

Fixes #40 