### PR TITLE
Never cache autoindex responses

### DIFF
--- a/ansible/roles/nginx/templates/connectbox_icon-only.conf.j2
+++ b/ansible/roles/nginx/templates/connectbox_icon-only.conf.j2
@@ -20,5 +20,9 @@ server {
       autoindex_format json;
       charset utf-8;
       charset_types application/json;
+      # Never cache the indexes
+      location ~ /$ {
+        expires -1;
+      }
     }
 }


### PR DESCRIPTION
When an initial setup was producing empty index responses (probably due to a solved error), Android appeared to be caching those empty index responses. As we do not set any expiry or cache control headers, this was causing ongoing problems. We (still) do not want to expire content.

FYI: @kldavis4 

Before:
```
$ curl -I http://neo.connectbox/content/
HTTP/1.1 200 OK
Server: nginx/1.10.3
Date: Fri, 15 Sep 2017 22:50:21 GMT
Content-Type: application/json; charset=utf-8
Connection: keep-alive

$ curl -I http://neo.connectbox/content/Help/
HTTP/1.1 200 OK
Server: nginx/1.10.3
Date: Fri, 15 Sep 2017 22:50:29 GMT
Content-Type: application/json; charset=utf-8
Connection: keep-alive

$ curl -I http://neo.connectbox/content/Help/help.txt
HTTP/1.1 200 OK
Server: nginx/1.10.3
Date: Fri, 15 Sep 2017 22:50:32 GMT
Content-Type: text/plain
Content-Length: 18
Last-Modified: Fri, 15 Sep 2017 22:29:24 GMT
Connection: keep-alive
ETag: "59bc5444-12"
Accept-Ranges: bytes
```

After:
```
$ curl -I http://neo.connectbox/content/
HTTP/1.1 200 OK                        
Server: nginx/1.10.3                   
Date: Fri, 15 Sep 2017 22:45:05 GMT    
Content-Type: application/json; charset=utf-8                                  
Connection: keep-alive                 
Expires: Fri, 15 Sep 2017 22:45:04 GMT 
Cache-Control: no-cache                

$ curl -I http://neo.connectbox/content/Help/
HTTP/1.1 200 OK                        
Server: nginx/1.10.3                   
Date: Fri, 15 Sep 2017 22:45:10 GMT    
Content-Type: application/json; charset=utf-8                                  
Connection: keep-alive                 
Expires: Fri, 15 Sep 2017 22:45:09 GMT 
Cache-Control: no-cache                

$ curl -I http://neo.connectbox/content/Help/help.txt
HTTP/1.1 200 OK                        
Server: nginx/1.10.3                   
Date: Fri, 15 Sep 2017 22:45:13 GMT    
Content-Type: text/plain               
Content-Length: 18                     
Last-Modified: Fri, 15 Sep 2017 22:29:24 GMT                                   
Connection: keep-alive                 
ETag: "59bc5444-12"                    
Accept-Ranges: bytes                   
```