### PR TITLE
Stop all automated apty services

### DIFF
--- a/ansible/group_vars/armbian
+++ b/ansible/group_vars/armbian
@@ -1,3 +1,7 @@
 ---
 connectbox_os: armbian
 ansible_user: root
+apty_services:
+  - unattended-upgrades
+  - apt-daily
+  - apt-daily-upgrade

--- a/ansible/group_vars/ubuntu
+++ b/ansible/group_vars/ubuntu
@@ -3,4 +3,6 @@ connectbox_os: ubuntu
 nginx_default_release: xenial
 php_service: php7.0-fpm
 fastcgi_pass_sock: unix:/var/run/php/php7.0-fpm.sock
-
+apty_services:
+  - unattended-upgrades
+  - apt-daily

--- a/ansible/roles/bootstrap/defaults/main.yml
+++ b/ansible/roles/bootstrap/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # Official Debian repo. armhf ARMv7+
 jessie_backports_repo: deb http://httpredir.debian.org/debian jessie-backports main
+apty_services: []
 
 # Debian signing keys. Used for Debian and Armbian
 repo_signing_keys:

--- a/ansible/roles/bootstrap/tasks/main.yml
+++ b/ansible/roles/bootstrap/tasks/main.yml
@@ -77,11 +77,7 @@
       name: "{{ item }}"
       state: stopped
       enabled: no
-    with_items:
-    - unattended-upgrades
-    - apt-daily
-    - apt-daily-upgrade
-  when: ansible_distribution == "Ubuntu"
+    with_items: "{{ apty_services }}"
 
 # Needed by Debian and Ubuntu Official AMIs
 - name: Install aptitude

--- a/ansible/roles/bootstrap/tasks/main.yml
+++ b/ansible/roles/bootstrap/tasks/main.yml
@@ -69,19 +69,18 @@
   when: connectbox_os == "armbian"
   tags: resize_root_partition
 
-# Disable unattended upgrades before attempting to install packages
-# (stop service, then remove entirely)
-# unattended-upgrades only runs on Ubuntu
+# Disable automated apt-y things before attempting to install packages
+# unattended-upgrades and apt.systemd.daily only run on Ubuntu
 - block:
-  - name: Stop unattended-upgrades service
+  - name: Stop automated apty services
     service:
-      name: unattended-upgrades
+      name: "{{ item }}"
       state: stopped
-
-  - name: Uninstall unattended-upgrades service
-    apt:
-      name: unattended-upgrades
-      state: absent
+      enabled: no
+    with_items:
+    - unattended-upgrades
+    - apt-daily
+    - apt-daily-upgrade
   when: ansible_distribution == "Ubuntu"
 
 # Needed by Debian and Ubuntu Official AMIs


### PR DESCRIPTION
We’ll manage updates separately, and these services interfere with package installation during image creation.