### PR TITLE
Constrain channel to valid values in the UI

### DIFF
--- a/html/admin/index.html
+++ b/html/admin/index.html
@@ -129,10 +129,24 @@
       </div>
       <p class="lead">Configure the channel used by the Wireless Access Point</p>
           <form class="simple_form form-inline" id="form_channel">
-              <div class="form-group required"><label class="required sr-only" for="channel"><abbr title="required">*</abbr> Channel</label><input class="string required form-control" id="input_channel" name="channel" placeholder="Enter Channel" type="text"></div>
-
-              <input class="btn btn-default" name="update_channel" type="submit" value="Update">
-              <div style="display:none" id="update_channel_success">✓</div>
+            <div class="form-group required"><label class="required sr-only" for="channel"><abbr title="required">*</abbr> Channel</label>
+              <select class="string required form-control" id="input_channel" name="channel">
+		<!-- Ultimately populate this with the acceptable channels, which would be exposed via the API -->
+		<option value="1">1</option>
+		<option value="2">2</option>
+		<option value="3">3</option>
+		<option value="4">4</option>
+		<option value="5">5</option>
+		<option value="6">6</option>
+		<option value="7">7</option>
+		<option value="8">8</option>
+		<option value="9">9</option>
+		<option value="10">10</option>
+		<option value="11">11</option>
+              </select>
+            </div>
+            <input class="btn btn-default" name="update_channel" type="submit" value="Update">
+            <div style="display:none" id="update_channel_success">✓</div>
         </form>
     </div>
 

--- a/html/admin/index.html
+++ b/html/admin/index.html
@@ -132,17 +132,17 @@
             <div class="form-group required"><label class="required sr-only" for="channel"><abbr title="required">*</abbr> Channel</label>
               <select class="string required form-control" id="input_channel" name="channel">
 		<!-- Ultimately populate this with the acceptable channels, which would be exposed via the API -->
-		<option value="1">1</option>
-		<option value="2">2</option>
-		<option value="3">3</option>
-		<option value="4">4</option>
-		<option value="5">5</option>
-		<option value="6">6</option>
-		<option value="7">7</option>
-		<option value="8">8</option>
-		<option value="9">9</option>
-		<option value="10">10</option>
-		<option value="11">11</option>
+		<option>1</option>
+		<option>2</option>
+		<option>3</option>
+		<option>4</option>
+		<option>5</option>
+		<option>6</option>
+		<option>7</option>
+		<option>8</option>
+		<option>9</option>
+		<option>10</option>
+		<option>11</option>
               </select>
             </div>
             <input class="btn btn-default" name="update_channel" type="submit" value="Update">

--- a/html/admin/js/connectbox-ui.js
+++ b/html/admin/js/connectbox-ui.js
@@ -208,9 +208,7 @@ var ConnectBoxApp = (function (ConnectBoxApp, $) {
 
     ConnectBoxApp.api.getProperty('channel', function (result, code, message) {
       if (result) {
-        // the channel number is 1-based int, but the selectedIndex of the
-        //  HTMLSelectedElement is 0-based, so we subtract 1
-        $('#input_channel')[0].selectedIndex = result[0] - 1
+        $('#input_channel').val(result[0])
       } else {
         showError('Error reading channel', parseErrorMessage(message))
       }

--- a/html/admin/js/connectbox-ui.js
+++ b/html/admin/js/connectbox-ui.js
@@ -208,7 +208,9 @@ var ConnectBoxApp = (function (ConnectBoxApp, $) {
 
     ConnectBoxApp.api.getProperty('channel', function (result, code, message) {
       if (result) {
-        $('#input_channel').val(result[0])
+        // the channel number is 1-based int, but the selectedIndex of the
+        //  HTMLSelectedElement is 0-based, so we subtract 1
+        $('#input_channel')[0].selectedIndex = result[0] - 1
       } else {
         showError('Error reading channel', parseErrorMessage(message))
       }


### PR DESCRIPTION
The valid channel list is conservative, but will be valid for all
regulatory domains, but ultimately we should retrieve the valid
channels from the API, so that we can include channels that are
valid for the current regulatory domain.

Fixes #165 (even though someone could still brick the box using the API directly, that’s not an important use-case at this stage)

I’m not sure whether my use of `$('#input_channel')[0].selectedIndex` is appropriate. I was surprised that looking up an element by ID returned a list, but I’m in unfamiliar territory so wanted to call it out as potentially suspect.