### PR TITLE
Preserve usbhost1 dtb overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Current open Issues: https://github.com/ConnectBox/connectbox-pi/issues?q=is%3Ao
 # Unreleased
 
 *
+# 20180113
+
+* Fixed: Missing usbhost1 device tree because of aptitude/apt-mark interaction for held packages
 
 # 20180108
 

--- a/ansible/roles/bootstrap/tasks/main.yml
+++ b/ansible/roles/bootstrap/tasks/main.yml
@@ -79,11 +79,19 @@
     enabled: no
   with_items: "{{ apty_services }}"
 
+# Needed for package upgrades via ansible (aptitude safe-upgrade)
+- name: Install aptitude
+  apt:
+    name: aptitude
+    state: present
+
 # Prevent kernel and dtb upgrades on NEOs so that we don't hit
 #  https://github.com/ConnectBox/connectbox-pi/issues/149
 # This can eventually be removed once we've upstreamed usbhost
 #  dtb changes and we're confident that an in-field kernel upgrade
 #  won't cause problems for the device
+# We use aptitude instead of apt-hold because aptitude's first run clears
+#  the package holds which causes us to upgrade these packages.
 - block:
   - name: Retrieve list of pinned packages
     command: apt-mark showholds
@@ -93,24 +101,18 @@
   # Can't use jinja variables in when clause so we need to
   #  do this without a loop
   - name: Pin kernel and dtb packages
-    command: "apt-mark hold linux-dtb-dev-sun8i"
+    command: "aptitude hold linux-dtb-dev-sun8i"
     when: '"linux-dtb-dev-sun8i" not in pinned_packages.stdout'
 
   - name: Pin kernel and dtb packages
-    command: "apt-mark hold linux-image-dev-sun8i"
+    command: "aptitude hold linux-image-dev-sun8i"
     when: '"linux-image-dev-sun8i" not in pinned_packages.stdout'
 
   - name: Pin kernel and dtb packages
-    command: "apt-mark hold linux-u-boot-nanopineo-dev"
+    command: "aptitude hold linux-u-boot-nanopineo-dev"
     when: '"linux-u-boot-nanopineo-dev" not in pinned_packages.stdout'
 
   when: '"NanoPi NEO" in machine_type.stdout'
-
-# Needed for package upgrades via ansible (aptitude safe-upgrade)
-- name: Install aptitude
-  apt:
-    name: aptitude
-    state: present
 
 # mikegleasonjr.firewall assumes iptables but Armbian doesn't ship with it
 - name: Install iptables


### PR DESCRIPTION
We mark the packages as held using `apt-mark`. We do a final upgrade with `aptitude safe-upgrade` and even though `aptitude` is supposed to honour the holds, it doesn’t because it seems the first invocation of aptitude wipes the marks.

e.g.

```
root@nanopineo:~# apt-mark showholds
root@nanopineo:~# apt-mark hold linux-dtb-dev-sun8i linux-image-dev-sun8i linux-u-boot-nan
opineo-dev
linux-dtb-dev-sun8i set on hold.
linux-image-dev-sun8i set on hold.
linux-u-boot-nanopineo-dev set on hold.
root@nanopineo:~# apt-mark showholds
linux-dtb-dev-sun8i
linux-image-dev-sun8i
linux-u-boot-nanopineo-dev
root@nanopineo:~# aptitude
root@nanopineo:~# apt-mark showholds
root@nanopineo:~#
```