### PR TITLE
added in releases link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ See [docs/administration.md](docs/administration.md)
 
 See [docs/development.md](docs/development.md)
 
+# MicroSD Card Images/Releases
+See [https://github.com/ConnectBox/connectbox-pi/releases/](https://github.com/ConnectBox/connectbox-pi/releases/)


### PR DESCRIPTION
We really needed a link off the front page to get to the releases.