### PR TITLE
Move to armbian mainline 4.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Current open Issues: https://github.com/ConnectBox/connectbox-pi/issues?q=is%3Ao
 # Unreleased
 
 *
+
+# 20180122
+
+* Fixed: Corrupted /boot/armbianEnv.txt on unclean shutdown [Issue #220](https://github.com/ConnectBox/connectbox-pi/issues/220)
+* Fixed: Broken wifi on developer images when eth is unplugged
+
 # 20180113
 
 * Fixed: Missing usbhost1 device tree because of aptitude/apt-mark interaction for held packages

--- a/ansible/roles/bootstrap/tasks/main.yml
+++ b/ansible/roles/bootstrap/tasks/main.yml
@@ -14,12 +14,6 @@
   register: old_style_names
 
 - block:
-  - name: Create usbhost1 device tree overlay for NanoPi NEO internal USB port
-    shell: sed 's/hci0/hci1/g' /boot/dtb/overlay/sun8i-h3-usbhost0.dtbo > /boot/dtb/overlay/sun8i-h3-usbhost1.dtbo
-    args:
-      creates: /boot/dtb/overlay/sun8i-h3-usbhost1.dtbo
-      warn: False  # Can't use either lineinfile or template here
-
   # will have problems if overlay lines are already present, but as that's not
   #  something we see at the moment, we won't try to cater for it
   - name: Activate all usbhost overlays on NanoPi NEO
@@ -84,35 +78,6 @@
   apt:
     name: aptitude
     state: present
-
-# Prevent kernel and dtb upgrades on NEOs so that we don't hit
-#  https://github.com/ConnectBox/connectbox-pi/issues/149
-# This can eventually be removed once we've upstreamed usbhost
-#  dtb changes and we're confident that an in-field kernel upgrade
-#  won't cause problems for the device
-# We use aptitude instead of apt-hold because aptitude's first run clears
-#  the package holds which causes us to upgrade these packages.
-- block:
-  - name: Retrieve list of pinned packages
-    command: apt-mark showholds
-    register: pinned_packages
-    changed_when: False
-
-  # Can't use jinja variables in when clause so we need to
-  #  do this without a loop
-  - name: Pin kernel and dtb packages
-    command: "aptitude hold linux-dtb-dev-sun8i"
-    when: '"linux-dtb-dev-sun8i" not in pinned_packages.stdout'
-
-  - name: Pin kernel and dtb packages
-    command: "aptitude hold linux-image-dev-sun8i"
-    when: '"linux-image-dev-sun8i" not in pinned_packages.stdout'
-
-  - name: Pin kernel and dtb packages
-    command: "aptitude hold linux-u-boot-nanopineo-dev"
-    when: '"linux-u-boot-nanopineo-dev" not in pinned_packages.stdout'
-
-  when: '"NanoPi NEO" in machine_type.stdout'
 
 # Prevent corruption of armbianEnv.txt on unclean shutdown
 # This should be removed when we rebase our images against

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -47,7 +47,7 @@ On your desktop, mount the downloaded image and creating a file called ssh in th
 
 ## Install Armbian on NanoPi NEO, Orange Pi Zero or Pine64
 
-Download the appropriate image for your device from the [Armbian download area](https://www.armbian.com/download/) put it into an SD card. Armbian images using a Legacy or Mainline kernel, based on Ubuntu Xenial are supported, though Mainline offers better performance. The [Armbian Getting Started Guide](https://docs.armbian.com/User-Guide_Getting-Started/) is useful. Before running ansible, you need to login and set the root password per the Armbian Getting Started Guide.
+Download the appropriate base-image for your device from the [ConnectBox base-image download area](https://github.com/ConnectBox/armbian-build/releases) and put it onto an SD card. If there are no base images for your device at that location, look in the [Armbian download area](https://www.armbian.com/download/). We require an Armbian images running a Mainline kernel, based on Ubuntu Xenial or Debian Stretch (the legacy kernel may work, but is unsupported). The [Armbian Getting Started Guide](https://docs.armbian.com/User-Guide_Getting-Started/) is useful. Before running ansible, you need to login and set the root password per the Armbian Getting Started Guide.
 
 ## Setup SSH Keys
 


### PR DESCRIPTION
Overlays for usbhost0-3 exist by default (but are still not
enabled) so we no longer need to pin related packages or setup
the usbhost1 ourselves.

This requires our NEO armbian builds to be based off https://github.com/ConnectBox/armbian-build/releases/tag/base-image-180408 or newer

Fixes #149 #224 