### PR TITLE
Jit development mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project indentifies releases by release date.
 
 *
 
+# 20180630
+
+* Changed: Images no longer have ssh enabled by default. To enable ssh, create .connectbox/enable-ssh on your USB storage, insert the USB storage and boot the device. Please change the root password immediately after booting
+* Changed: The admin interface has been rewritten using React (matching the icon-only interface)
+
 # 20180604
 
 * Fixed: Prevent upstream armbian packages overwriting our kernel and uboot packages (this time compatible with aptitude's behaviour)

--- a/ansible/roles/connectbox-pi/files/sshswitch.service
+++ b/ansible/roles/connectbox-pi/files/sshswitch.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Activate sshd based on existance of user-managed file
+ConditionPathExists=/media/usb0/.connectbox/ssh
+# systemd-udevd mounts USB storage
+Wants=systemd-udevd.service
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c "systemctl is-active ssh.service || systemctl enable ssh.service && systemctl start ssh.service"
+[Install]
+WantedBy=multi-user.target
+

--- a/ansible/roles/connectbox-pi/files/sshswitch.service
+++ b/ansible/roles/connectbox-pi/files/sshswitch.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Activate sshd based on existance of user-managed file
-ConditionPathExists=/media/usb0/.connectbox/ssh
+ConditionPathExists=/media/usb0/.connectbox/enable-ssh
 # systemd-udevd mounts USB storage
 Wants=systemd-udevd.service
 [Service]

--- a/ansible/roles/connectbox-pi/handlers/main.yaml
+++ b/ansible/roles/connectbox-pi/handlers/main.yaml
@@ -1,4 +1,13 @@
 ---
+# No need to start this service given it's an at-boot one-shot
+# Must do a daemon reload so that systemd knows about this new service
+- name: Enable sshswitch service
+  systemd:
+    name: sshswitch.service
+    enabled: yes
+    daemon_reload: yes
+
+
 # Skip lint because there's no way that ansible-lint can know at build time
 #  that we're legitimately use shell because of the && that is always
 #  present when this is run.

--- a/ansible/roles/connectbox-pi/tasks/main.yml
+++ b/ansible/roles/connectbox-pi/tasks/main.yml
@@ -180,6 +180,13 @@
     state: absent
   when: not developer_mode and ansible_lsb["id"] == "Raspbian"
 
+- name: Add service to allow administrators to activate sshd
+  copy:
+    src: sshswitch.service
+    dest: /lib/systemd/system
+  when: not developer_mode and connectbox_os == "armbian"
+  notify: Enable sshswitch service
+
 # sshd forks child processes to handle connections, so stopping and disabling
 #  sshd doesn't disconnect the session that's actually doing the stopping and
 #  disabling (or the control session if pipelining is in use)

--- a/ansible/roles/connectbox-pi/tasks/main.yml
+++ b/ansible/roles/connectbox-pi/tasks/main.yml
@@ -180,19 +180,12 @@
     state: absent
   when: not developer_mode and ansible_lsb["id"] == "Raspbian"
 
-# Disable the main user account unless as password hash is provided
-- name: Schedule disabling of user account
-  set_fact:
-    final_command: "/usr/sbin/usermod --lock --shell /usr/sbin/nologin {{ ansible_user }}"
-  when: not developer_mode
-
 # sshd forks child processes to handle connections, so stopping and disabling
 #  sshd doesn't disconnect the session that's actually doing the stopping and
-#  disabling (or the control session if pipelining is in use) so we stop sshd
-#  before any potential commands to disable user accounts
+#  disabling (or the control session if pipelining is in use)
 - name: Schedule disabling of sshd
   set_fact:
-    final_command: "{{ (final_command == '') | ternary('systemctl disable ssh && systemctl stop ssh', ['systemctl disable ssh && systemctl stop ssh', final_command] | join(' && ')) }}"
+    final_command: "systemctl disable ssh && systemctl stop ssh"
   when: not developer_mode
 
 # Run the final commands in a handler so any disabling is performed right at

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,6 @@
 # Making a ConnectBox
 
-The ConnectBox runs on a few different devices, with a specific operating system for each. It requires Raspbian Lite (Stretch only) for Raspberry Pi 3 and Raspberry Pi Zero W devices and Armbian (Xenial only) for Orange Pi Zero and Pine64 devices. Pre-made images are available for select devices, and you can always install to your devices using Ansible (a tool for deployment, configuration management and orchestration) if you have an ethernet connection to the device.
+The ConnectBox runs on a few different devices, with a specific operating system for each. NanoPi NEO devices run on Armbian (Xenial only) and Raspberry Pi devices run Raspbian Lite (Stretch only). Other Armbian devices may work, but are untested. ConnectBox support for the Raspberry Pi can lag behind Armbian devices, but we do want to keep supporting Raspbian, so please let us know if you find problems. Pre-made images are available for select devices, and you can always install to your devices using Ansible (a tool for deployment, configuration management and orchestration) if you have an ethernet connection to the device.
 
 # Terminology
 
@@ -9,11 +9,22 @@ For simplicity, let's assume the following terms:
  Most importantly, the workstation is different to your _device_.
 * __device__: The ConnectBox hardware. It might be a Raspberry Pi 3, or it might be one of the other supported devices. When describing commands to be run on the device, we'll display the device prompt as `pi@rasberrypi: $` even though it will be different on other devices.
 
-## Get a pre-made image
+## Get a pre-made release image for the NanoPi NEO
 
-Pre-made images are distributed on GitHub (https://github.com/ConnectBox/connectbox-pi/releases) . If you don't see an image for your device, feel free to raise an issue or email us.
+Pre-made release images are distributed on GitHub (https://github.com/ConnectBox/connectbox-pi/releases) . If you don't see an image for your device, feel free to raise an issue or email us.
+
+### Enabling sshd on a pre-made release image
+
+sshd is not running on pre-made release images. To permanently enable it, make a directory called `.connectbox` on your USB storage device and place a file named `enable-ssh` in that folder. Insert your USB storage into the ConnectBox and power it on. Once the system has booted, you will be able to ssh to the ConnectBox as `root/connectbox`. Please change the root password immediately.
+
+## Install Armbian on NanoPi NEO from scratch
+
+Download the appropriate Armbian base-image for your device from the [ConnectBox base-image download area](https://github.com/ConnectBox/armbian-build/releases) and put it onto an SD card. If there are no base images for your device at that location, look in the [Armbian download area](https://www.armbian.com/download/). We require an Armbian images running a Mainline kernel, based on Ubuntu Xenial. The [Armbian Getting Started Guide](https://docs.armbian.com/User-Guide_Getting-Started/) is useful. Before running ansible, you need to login and set the root password per the Armbian Getting Started Guide.
+
 
 ## Install Vanilla Raspbian-lite on Raspberry Pi 3 or Raspberry Pi Zero W
+
+Pre-made release images for the Raspberry Pi are occasionally made and are distributed on GitHub (https://github.com/ConnectBox/connectbox-pi/releases) . If you don't see an image for your device, feel free to raise an issue or email us.
 
 Download the [current Raspbian Lite (Stretch)](https://www.raspberrypi.org/downloads/raspbian/). The Nov 2016 introduced a security update that disables the SSH daemon by default. The connectbox is deployed using Ansible, which connects to the Raspberry Pi over SSH, so ssh needs to be enabled. Enable sshd by one of the methods below (you only need to choose one):
 
@@ -44,10 +55,6 @@ pi@raspberrypi: $ sudo raspi-config
 ### Enabling sshd on the operating system image
 
 On your desktop, mount the downloaded image and creating a file called ssh in the `/boot` directory. Once the image has been updated to enabled ssh, [put the image on an SD card](https://www.raspberrypi.org/documentation/installation/installing-images/) and boot the Raspberry Pi from it.
-
-## Install Armbian on NanoPi NEO, Orange Pi Zero or Pine64
-
-Download the appropriate base-image for your device from the [ConnectBox base-image download area](https://github.com/ConnectBox/armbian-build/releases) and put it onto an SD card. If there are no base images for your device at that location, look in the [Armbian download area](https://www.armbian.com/download/). We require an Armbian images running a Mainline kernel, based on Ubuntu Xenial or Debian Stretch (the legacy kernel may work, but is unsupported). The [Armbian Getting Started Guide](https://docs.armbian.com/User-Guide_Getting-Started/) is useful. Before running ansible, you need to login and set the root password per the Armbian Getting Started Guide.
 
 ## Setup SSH Keys
 
@@ -179,7 +186,7 @@ user@ubuntu:~$
 
 ## Get Ansible
 
-This project uses Ansible v2.1 or above. 
+This project uses Ansible v2.4 or above. 
 
 Package managers generally have an out-dated version of ansible, but the [Ansible documentation](http://docs.ansible.com/ansible/intro_installation.html#installing-the-control-machine) lists methods for obtaining a current version of Ansible for common platforms.
 
@@ -196,7 +203,7 @@ The developing.md file lists an alternative method for setting up Ansible using 
 
 ## Run Ansible
 
-__A default ansible-playbook run will disable sshd and lock out the default user account. Read "Optional Ansible Arguments" if you don't want this__
+__A default ansible-playbook run will disable sshd. Read "Optional Ansible Arguments" if you don't want this__
 
 The rest of this guide assumes that your device is attached to the network via its ethernet port, so that the wifi interface can be configured as an Access Point.
 
@@ -283,10 +290,10 @@ To use these arguments, add them to the inventory file or add `-e option_name=va
 
 - __deploy_sample_content__ _(default: true)_: Installs sample files to demonstrate ConnectBox functionality.
 - __ssid__ _(default: ConnectBox - Free Media)_: The Wireless SSID can be changed from the admin interface but it can also be changed at deployment time.
-- __developer_mode__ _(default: false)_: Developer mode leaves the device in an insecure state, but makes it possible to examine the internal state of the ConnectBox. When developer mode is false _(think, production mode)_, sshd is stopped and disabled by default at the end of the ansible playbook run, and the user account is locked (with `usermod -L`). This is done to prevent unauthorised remote access and console access, particularly if operating system default passwords are not changed. If you have inadvertently locked yourself out, the [Raspbian security update](https://www.raspberrypi.org/blog/a-security-update-for-raspbian-pixel/) describes how to re-enable sshd and you can re-enable the account using information at RaspberryPi Spy - [Reset a lost Raspberry Pi password)[http://www.raspberrypi-spy.co.uk/2014/08/how-to-reset-a-forgotten-raspberry-pi-password/)
+- __developer_mode__ _(default: false)_: Developer mode leaves the device in an insecure state, but makes it possible to examine the internal state of the ConnectBox. When developer mode is false _(think, production mode)_, sshd is stopped and disabled by default at the end of the ansible playbook run. This is done to prevent unauthorised remote access and console access, particularly if operating system default passwords are not changed. If you have inadvertently locked yourself out, the [Raspbian security update](https://www.raspberrypi.org/blog/a-security-update-for-raspbian-pixel/) describes how to re-enable sshd and you can re-enable the account using information at RaspberryPi Spy - [Reset a lost Raspberry Pi password)[http://www.raspberrypi-spy.co.uk/2014/08/how-to-reset-a-forgotten-raspberry-pi-password/)
 - __connectbox_default_hostname__ _(default: connectbox)_: Change the host name of the Connectbox (visible in the URL field when browsing)
 - __interface_type__ _(default: icon_only)_: This selects how to present the user-defined content (i.e. the attached USB storage or the contents of `/media/usb0` if USB storage is not being used). _"icon_only"_ mode presents an icon-only browseable web interface of the user-defined content. _"static_site"_ mode assumes the user-defined content is a static web site and displays the site.
-- __do_image_preparation__ _(default: false__: Performs tasks required for preparation of an image for distribution, including halting the device at the end of the ansible run.
+- __do_image_preparation__ _(default: false)_: Performs tasks required for preparation of an image for distribution, including halting the device at the end of the ansible run.
 
 ## Use the ConnectBox
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@ If you're developing the interface, it's often faster to do development on a vir
 
 ## Get Ansible
 
-Whether you're using Vagrant or developing directly against a device, you'll need Ansible to perform the setup. To develop the Ansible playbooks, or develop the ConnectBox software, you'll need to have Ansible 2.1+ and some extra tools. From the directory containing this README, run:
+Whether you're using Vagrant or developing directly against a device, you'll need Ansible to perform the setup. To develop the Ansible playbooks, or develop the ConnectBox software, you'll need to have Ansible 2.4+ and some extra tools. From the directory containing this README, run:
 
 ```bash
 $ mkdir ~/.virtualenvs
@@ -22,11 +22,20 @@ $ pip install -r requirements.txt
 1. Run the tests. In the same directory as the `Vagrantfile` run: `TEST_IP=172.28.128.3 python -m unittest discover tests` (assuming your VM IP address is `172.28.128.3`). All the tests should pass.
 1. The WiFi Point is not active when running from a virtual machine, but you can still view the ConnectBox Site by browsing to the address e.g. http://ubuntu-vagrant.connectbox/
 
-## Developing against a Device
+## Developing against a device from a base image
 
 1. This is identical to deploying a new device, so follow the instructions in the [deployment.md](deployment.md) documentation. You probably want to run the Ansible playbook many times as you do your development, so you will likely want to specify the `developer_mode` variable on your commandline on in the Ansible inventory.
 
+## Developing against a device from a ConnectBox release image
+
+Pre-made release images are distributed on GitHub (https://github.com/ConnectBox/connectbox-pi/releases) . sshd is not running on pre-made release images. To permanently enable it, make a directory called `.connectbox` on your USB storage device and place a file named `enable-ssh` in that folder. Insert your USB storage into the ConnectBox and power it on. Once the system has booted, you will be able to ssh to the ConnectBox as `root/connectbox`. Please change the root password immediately.
+
+## Connecting to the ConnectBox
+
 1. You can access the ConnectBox site by connecting to a WiFi point named "ConnectBox - Free Media". Once connected to the WiFi point, go somewhere (anywhere) in your browser and you should be redirected to the ConnectBox site.
 1. You can also access the ConnectBox Site over ethernet. To do so add an entry in `/etc/hosts` on the machine where you ran Ansible, add the line `<ip-of-your-device> connectbox` . Then browse to http://connectbox
-1. Run the tests. In this directory: `TEST_IP=<ip-of-your-device> python -m unittest discover tests` . All the tests should pass.
+
+# Tests
+
+1. We have a test suite. From the parent directory of this document, run: `TEST_IP=<ip-of-your-device> python -m unittest discover tests` . All the tests should pass.
 


### PR DESCRIPTION
ssh is now disabled on all pre-made connectbox images. To enable it, create a file called .connectbox/enable-ssh on the USB storage, insert it and reboot.