### PR TITLE
Android 7 cp fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,18 @@ This project indentifies releases by release date.
 
 # Unreleased
 
-* Add optimised 2.4Ghz parameters for the likely next wifi chipset (rtl8812au)
+*
+
+# 20180728
+
+* Fixed: Android 7 devices only showed captive portal instructions momentarily [Issue #251](https://github.com/ConnectBox/connectbox-pi/issues/251)
+* Changed: Display a link rather than a text URL in the captive portal for MacOS 10.13 (High Sierra) devices
+* Changed: Display a link rather than a text URL in the captive portal for iOS 11 devices
+
+# 20180717
+
+* Added: Optimised 2.4Ghz parameters for the likely next wifi chipset (rtl8812au)
+* Fixed: Android 8 devices with active celluar connections were unable to remain connected to the captive portal [Issue #250](https://github.com/ConnectBox/connectbox-pi/issues/250)
 
 # 20180708
 

--- a/python/captive_portal/manager.py
+++ b/python/captive_portal/manager.py
@@ -101,15 +101,17 @@ def get_link_type(ua_str):
     """
     user_agent = user_agent_parser.Parse(ua_str)
     if user_agent["os"]["family"] == "iOS" and \
-            user_agent["os"]["major"] == "9":
-        # iOS 9 can open links from the captive portal agent in the browser
+            user_agent["os"]["major"] in ("9", "11"):
+        # iOS 9 and iOS 11 can open links from the captive portal browser
+        #  in the system browser. iOS 10 cannot - the link opens in the
+        #  captive portal browser itself.
         return LINK_OPS["HREF"]
 
     if user_agent["os"]["family"] == "Mac OS X" and \
             user_agent["os"]["major"] == "10" and \
-            user_agent["os"]["minor"] == "12":
-        # Sierra (10.12) can open links from the captive portal agent in
-        #  the browser
+       user_agent["os"]["minor"] in ("12", "13"):
+        # Sierra (10.12) and High Sierra (10.13) can open links from the
+        #  captive portal browser in the system browser
         return LINK_OPS["HREF"]
 
     return LINK_OPS["TEXT"]

--- a/tests/test_connectbox_static.py
+++ b/tests/test_connectbox_static.py
@@ -469,8 +469,9 @@ class ConnectBoxDefaultVHostTestCase(unittest.TestCase):
         # 6. Connectbox replies that internet access is still not available
         #    because we don't want to close the cpb
         self.assertEqual(r.status_code, 200)
-        # We wait for 30 seconds
-        time.sleep(30)
+        # We wait for 30 seconds (just a little longer than
+        #  ANDROID_7_CPA_MAX_SECS_WITHOUT_204)
+        time.sleep(35)
         # 6. Captive portal agent sends the same request, now that the
         #    witholding 204 perioud is done.
         headers.update({"User-Agent": cpa_ua})

--- a/tests/test_connectbox_static.py
+++ b/tests/test_connectbox_static.py
@@ -1,5 +1,6 @@
 import json
 import os
+import time
 import unittest
 import random
 import dns.resolver


### PR DESCRIPTION
Make the captive portal browser stay open so users can read instructions
Switch to hrefs instead of text URLs on macOS 10.13 and iOS 11