### PR TITLE
Set locale

### DIFF
--- a/ansible/roles/bootstrap/tasks/main.yml
+++ b/ansible/roles/bootstrap/tasks/main.yml
@@ -64,6 +64,12 @@
     timeout=300
   when: reboot_required
 
+- name: Set default locale
+  lineinfile:
+    path=/etc/default/locale
+    state=present
+    line="LC_ALL=en_US.UTF-8"
+
 # Needed for package upgrades via ansible (aptitude safe-upgrade)
 - name: Install aptitude
   apt:


### PR DESCRIPTION
This might be brutish, but we do want to give the command line
tools some locale so that it doesn't spit errors on the screen
when running perl or trying to create python virtualenvs