### PR TITLE
Disable non-OFDM Wifi rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ This project indentifies releases by release date.
 
 # Unreleased
 
+* Changed: Disabled non-OFDM Wifi rates to improve overall throughput when a connected client has a bad connection
+
+# 20181021
+
 * Fixed: Allow sshd to be enabled on Raspberry Pi devices by the usual .connectbox/enable-ssh method via USB storage
+* Added: "Return to main interface" button in the admin area [Issue #274](https://github.com/ConnectBox/connectbox-pi/issues/274)
 
 # 20181016
 

--- a/ansible/roles/wifi-ap/templates/hostapd.conf.j2
+++ b/ansible/roles/wifi-ap/templates/hostapd.conf.j2
@@ -21,6 +21,18 @@ ieee80211n=1
 channel={{ wireless_channel }}
 macaddr_acl=0 # accept unless in deny list
 
+# Disable non-OFDM rates given they consume disproportiately large amounts
+#  of airtime and aren't required for modern devices
+supported_rates=60 90 120 180 240 360 480 540
+basic_rates=60 120 240
+
+{% if connectbox_os == "armbian" %}
+# Beacon rate is minimum OFDM rate
+# beacon_rate is only available on hostapd >= v2.6, which only
+#  ships with armbian
+beacon_rate=60
+{% endif %}
+
 # IEEE 802.11 specifies two authentication algorithms. hostapd can be
 # configured to allow both of these or only one. Open system authentication
 # should be used with IEEE 802.1X.

--- a/ansible/roles/wifi-ap/templates/hostapd.conf.j2
+++ b/ansible/roles/wifi-ap/templates/hostapd.conf.j2
@@ -26,13 +26,6 @@ macaddr_acl=0 # accept unless in deny list
 supported_rates=60 90 120 180 240 360 480 540
 basic_rates=60 120 240
 
-{% if connectbox_os == "armbian" %}
-# Beacon rate is minimum OFDM rate
-# beacon_rate is only available on hostapd >= v2.6, which only
-#  ships with armbian
-beacon_rate=60
-{% endif %}
-
 # IEEE 802.11 specifies two authentication algorithms. hostapd can be
 # configured to allow both of these or only one. Open system authentication
 # should be used with IEEE 802.1X.


### PR DESCRIPTION
non-OFDM rates use a disproportionately large amount of airtime
and aren't needed by modern clients, so let's disabled them in
order to have more airtime available when there are clients on
a network that have a poor connection

Closes #116 