### PR TITLE
Add libfreetype. Start hat service earlier

### DIFF
--- a/ansible/roles/image-preparation/tasks/main.yml
+++ b/ansible/roles/image-preparation/tasks/main.yml
@@ -132,7 +132,6 @@
     - libdpkg-perl
     - liberror-perl
     - libfftw3-double3
-    - libfreetype6
     - libgd3
     - libgeoip1
     - libgomp1

--- a/ansible/roles/neo-battery-tools/templates/neo-battery-shutdown.service.j2
+++ b/ansible/roles/neo-battery-tools/templates/neo-battery-shutdown.service.j2
@@ -6,7 +6,7 @@ After=multi-user.target {{ pa_pulldown_enabler_service_name }}
 Requires={{ pa_pulldown_enabler_service_name }}
 
 [Service]
-Type=idle
+Type=simple
 ExecStart={{ battery_tool_virtualenv_dir }}/bin/neo_batterylevelshutdown
 
 [Install]


### PR DESCRIPTION
libfreetype is needed for OLED HATs. Don't remove it.